### PR TITLE
feat: add column_family keyspace metrics

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -576,6 +576,310 @@
 
 				<tr>
 				<td>64</td>
+				<td class="metric">scylla_column_family_cache_hit_rate</td>
+				<td>gauge</td>
+				<td>Cache hit rate</td>
+				</tr>
+			
+
+				<tr>
+				<td>65</td>
+				<td class="metric">scylla_column_family_cas_commit_latency</td>
+				<td>histogram</td>
+				<td>CAS learn round latency histogram</td>
+				</tr>
+			
+
+				<tr>
+				<td>66</td>
+				<td class="metric">scylla_column_family_cas_commit_latency_summary</td>
+				<td>summary</td>
+				<td>CAS learn round latency summary</td>
+				</tr>
+			
+
+				<tr>
+				<td>67</td>
+				<td class="metric">scylla_column_family_cas_prepare_latency</td>
+				<td>histogram</td>
+				<td>CAS prepare round latency histogram</td>
+				</tr>
+			
+
+				<tr>
+				<td>68</td>
+				<td class="metric">scylla_column_family_cas_prepare_latency_summary</td>
+				<td>summary</td>
+				<td>CAS prepare round latency summary</td>
+				</tr>
+			
+
+				<tr>
+				<td>69</td>
+				<td class="metric">scylla_column_family_cas_propose_latency</td>
+				<td>histogram</td>
+				<td>CAS accept round latency histogram</td>
+				</tr>
+			
+
+				<tr>
+				<td>70</td>
+				<td class="metric">scylla_column_family_cas_propose_latency_summary</td>
+				<td>summary</td>
+				<td>CAS accept round latency summary</td>
+				</tr>
+			
+
+				<tr>
+				<td>71</td>
+				<td class="metric">scylla_column_family_live_disk_space</td>
+				<td>gauge</td>
+				<td>Live disk space used</td>
+				</tr>
+			
+
+				<tr>
+				<td>72</td>
+				<td class="metric">scylla_column_family_live_sstable</td>
+				<td>gauge</td>
+				<td>Live sstable count</td>
+				</tr>
+			
+
+				<tr>
+				<td>73</td>
+				<td class="metric">scylla_column_family_memtable_partition_hits</td>
+				<td>counter</td>
+				<td>Number of times a write operation was issued on an existing partition in memtables</td>
+				</tr>
+			
+
+				<tr>
+				<td>74</td>
+				<td class="metric">scylla_column_family_memtable_partition_writes</td>
+				<td>counter</td>
+				<td>Number of write operations performed on partitions in memtables</td>
+				</tr>
+			
+
+				<tr>
+				<td>75</td>
+				<td class="metric">scylla_column_family_memtable_row_hits</td>
+				<td>counter</td>
+				<td>Number of rows overwritten by write operations in memtables</td>
+				</tr>
+			
+
+				<tr>
+				<td>76</td>
+				<td class="metric">scylla_column_family_memtable_row_tombstone_reads</td>
+				<td>counter</td>
+				<td>Number of row tombstones read from memtables</td>
+				</tr>
+			
+
+				<tr>
+				<td>77</td>
+				<td class="metric">scylla_column_family_memtable_row_writes</td>
+				<td>counter</td>
+				<td>Number of row writes performed in memtables</td>
+				</tr>
+			
+
+				<tr>
+				<td>78</td>
+				<td class="metric">scylla_column_family_memtable_rows_compacted_with_tombstones</td>
+				<td>counter</td>
+				<td>Number of rows scanned during write of a tombstone for the purpose of compaction in memtables</td>
+				</tr>
+			
+
+				<tr>
+				<td>79</td>
+				<td class="metric">scylla_column_family_memtable_rows_dropped_by_tombstones</td>
+				<td>counter</td>
+				<td>Number of rows dropped in memtables by a tombstone write</td>
+				</tr>
+			
+
+				<tr>
+				<td>80</td>
+				<td class="metric">scylla_column_family_memtable_switch</td>
+				<td>counter</td>
+				<td>Number of times flush has resulted in the memtable being switched out</td>
+				</tr>
+			
+
+				<tr>
+				<td>81</td>
+				<td class="metric">scylla_column_family_pending_compaction</td>
+				<td>gauge</td>
+				<td>Estimated number of compactions pending for this column family</td>
+				</tr>
+			
+
+				<tr>
+				<td>82</td>
+				<td class="metric">scylla_column_family_pending_sstable_deletions</td>
+				<td>gauge</td>
+				<td>Number of tasks waiting to delete sstables from a table</td>
+				</tr>
+			
+
+				<tr>
+				<td>83</td>
+				<td class="metric">scylla_column_family_pending_tasks</td>
+				<td>gauge</td>
+				<td>Estimated number of tasks pending for this column family</td>
+				</tr>
+			
+
+				<tr>
+				<td>84</td>
+				<td class="metric">scylla_column_family_read_latency</td>
+				<td>histogram</td>
+				<td>Read latency histogram</td>
+				</tr>
+			
+
+				<tr>
+				<td>85</td>
+				<td class="metric">scylla_column_family_read_latency_summary</td>
+				<td>summary</td>
+				<td>Read latency summary</td>
+				</tr>
+			
+
+				<tr>
+				<td>86</td>
+				<td class="metric">scylla_column_family_row_lock_exclusive_partition_acquisitions</td>
+				<td>counter</td>
+				<td>Row lock acquisitions for exclusive_partition lock</td>
+				</tr>
+			
+
+				<tr>
+				<td>87</td>
+				<td class="metric">scylla_column_family_row_lock_exclusive_partition_operations_currently_waiting_for_lock</td>
+				<td>gauge</td>
+				<td>Operations currently waiting for exclusive_partition lock</td>
+				</tr>
+			
+
+				<tr>
+				<td>88</td>
+				<td class="metric">scylla_column_family_row_lock_exclusive_partition_waiting_time</td>
+				<td>histogram</td>
+				<td>Histogram representing time that operations spent on waiting for exclusive_partition lock</td>
+				</tr>
+			
+
+				<tr>
+				<td>89</td>
+				<td class="metric">scylla_column_family_row_lock_exclusive_row_acquisitions</td>
+				<td>counter</td>
+				<td>Row lock acquisitions for exclusive_row lock</td>
+				</tr>
+			
+
+				<tr>
+				<td>90</td>
+				<td class="metric">scylla_column_family_row_lock_exclusive_row_operations_currently_waiting_for_lock</td>
+				<td>gauge</td>
+				<td>Operations currently waiting for exclusive_row lock</td>
+				</tr>
+			
+
+				<tr>
+				<td>91</td>
+				<td class="metric">scylla_column_family_row_lock_exclusive_row_waiting_time</td>
+				<td>histogram</td>
+				<td>Histogram representing time that operations spent on waiting for exclusive_row lock</td>
+				</tr>
+			
+
+				<tr>
+				<td>92</td>
+				<td class="metric">scylla_column_family_row_lock_shared_partition_operations_currently_waiting_for_lock</td>
+				<td>gauge</td>
+				<td>Operations currently waiting for shared_partition lock</td>
+				</tr>
+			
+
+				<tr>
+				<td>93</td>
+				<td class="metric">scylla_column_family_row_lock_shared_row_operations_currently_waiting_for_lock</td>
+				<td>gauge</td>
+				<td>Operations currently waiting for shared_row lock</td>
+				</tr>
+			
+
+				<tr>
+				<td>94</td>
+				<td class="metric">scylla_column_family_total_disk_space</td>
+				<td>gauge</td>
+				<td>Total disk space used</td>
+				</tr>
+			
+
+				<tr>
+				<td>95</td>
+				<td class="metric">scylla_column_family_view_updates_failed_local</td>
+				<td>counter</td>
+				<td>Number of updates (mutations) that failed to be pushed to local view replicas</td>
+				</tr>
+			
+
+				<tr>
+				<td>96</td>
+				<td class="metric">scylla_column_family_view_updates_failed_remote</td>
+				<td>counter</td>
+				<td>Number of updates (mutations) that failed to be pushed to remote view replicas</td>
+				</tr>
+			
+
+				<tr>
+				<td>97</td>
+				<td class="metric">scylla_column_family_view_updates_pending</td>
+				<td>gauge</td>
+				<td>Number of updates pushed to view and are still to be completed</td>
+				</tr>
+			
+
+				<tr>
+				<td>98</td>
+				<td class="metric">scylla_column_family_view_updates_pushed_local</td>
+				<td>counter</td>
+				<td>Number of updates (mutations) pushed to local view replicas</td>
+				</tr>
+			
+
+				<tr>
+				<td>99</td>
+				<td class="metric">scylla_column_family_view_updates_pushed_remote</td>
+				<td>counter</td>
+				<td>Number of updates (mutations) pushed to remote view replicas</td>
+				</tr>
+			
+
+				<tr>
+				<td>100</td>
+				<td class="metric">scylla_column_family_write_latency</td>
+				<td>histogram</td>
+				<td>Write latency histogram</td>
+				</tr>
+			
+
+				<tr>
+				<td>101</td>
+				<td class="metric">scylla_column_family_write_latency_summary</td>
+				<td>summary</td>
+				<td>Write latency summary</td>
+				</tr>
+			
+
+				<tr>
+				<td>102</td>
 				<td class="metric">scylla_commitlog_active_allocations</td>
 				<td>gauge</td>
 				<td>Current number of active allocations.</td>
@@ -583,7 +887,7 @@
 			
 
 				<tr>
-				<td>65</td>
+				<td>103</td>
 				<td class="metric">scylla_commitlog_alloc</td>
 				<td>counter</td>
 				<td>Counts number of times a new mutation has been added to a segment. Divide bytes_written by this value to get the average number of bytes per mutation written to the disk.</td>
@@ -591,7 +895,7 @@
 			
 
 				<tr>
-				<td>66</td>
+				<td>104</td>
 				<td class="metric">scylla_commitlog_allocating_segments</td>
 				<td>gauge</td>
 				<td>Holds the number of not closed segments that still have some free space. This value should not get too high.</td>
@@ -599,7 +903,7 @@
 			
 
 				<tr>
-				<td>67</td>
+				<td>105</td>
 				<td class="metric">scylla_commitlog_blocked_on_new_segment</td>
 				<td>gauge</td>
 				<td>Number of allocations blocked on acquiring new segment.</td>
@@ -607,7 +911,7 @@
 			
 
 				<tr>
-				<td>68</td>
+				<td>106</td>
 				<td class="metric">scylla_commitlog_bytes_flush_requested</td>
 				<td>counter</td>
 				<td>Counts number of bytes requested to be flushed (persisted).</td>
@@ -615,7 +919,7 @@
 			
 
 				<tr>
-				<td>69</td>
+				<td>107</td>
 				<td class="metric">scylla_commitlog_bytes_released</td>
 				<td>counter</td>
 				<td>Counts number of bytes released from disk. (Deleted/recycled)</td>
@@ -623,7 +927,7 @@
 			
 
 				<tr>
-				<td>70</td>
+				<td>108</td>
 				<td class="metric">scylla_commitlog_bytes_written</td>
 				<td>counter</td>
 				<td>Counts number of bytes written to the disk. Divide this value by "alloc" to get the average number of bytes per mutation written to the disk.</td>
@@ -631,7 +935,7 @@
 			
 
 				<tr>
-				<td>71</td>
+				<td>109</td>
 				<td class="metric">scylla_commitlog_cycle</td>
 				<td>counter</td>
 				<td>Counts number of commitlog write cycles - when the data is written from the internal memory buffer to the disk.</td>
@@ -639,7 +943,7 @@
 			
 
 				<tr>
-				<td>72</td>
+				<td>110</td>
 				<td class="metric">scylla_commitlog_disk_active_bytes</td>
 				<td>gauge</td>
 				<td>Holds size of disk space in bytes used for data so far. A too high value indicates that we have some bottleneck in the writing to sstables path.</td>
@@ -647,7 +951,7 @@
 			
 
 				<tr>
-				<td>73</td>
+				<td>111</td>
 				<td class="metric">scylla_commitlog_disk_slack_end_bytes</td>
 				<td>gauge</td>
 				<td>Holds size of disk space in bytes unused because of segment switching (end slack). A too high value indicates that we do not write enough data to each segment.</td>
@@ -655,7 +959,7 @@
 			
 
 				<tr>
-				<td>74</td>
+				<td>112</td>
 				<td class="metric">scylla_commitlog_disk_total_bytes</td>
 				<td>gauge</td>
 				<td>Holds size of disk space in bytes reserved for data so far. A too high value indicates that we have some bottleneck in the writing to sstables path.</td>
@@ -663,7 +967,7 @@
 			
 
 				<tr>
-				<td>75</td>
+				<td>113</td>
 				<td class="metric">scylla_commitlog_flush</td>
 				<td>counter</td>
 				<td>Counts number of times the flush() method was called for a file.</td>
@@ -671,7 +975,7 @@
 			
 
 				<tr>
-				<td>76</td>
+				<td>114</td>
 				<td class="metric">scylla_commitlog_flush_limit_exceeded</td>
 				<td>counter</td>
 				<td>Counts number of times a flush limit was exceeded. A non-zero value indicates that there are too many pending flush operations (see pending_flushes) and some of them will be blocked till the total amount of pending flush operations drops below 5.</td>
@@ -679,7 +983,7 @@
 			
 
 				<tr>
-				<td>77</td>
+				<td>115</td>
 				<td class="metric">scylla_commitlog_memory_buffer_bytes</td>
 				<td>gauge</td>
 				<td>Holds the total number of bytes in internal memory buffers.</td>
@@ -687,7 +991,7 @@
 			
 
 				<tr>
-				<td>78</td>
+				<td>116</td>
 				<td class="metric">scylla_commitlog_pending_allocations</td>
 				<td>gauge</td>
 				<td>Holds number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.</td>
@@ -695,7 +999,7 @@
 			
 
 				<tr>
-				<td>79</td>
+				<td>117</td>
 				<td class="metric">scylla_commitlog_pending_flushes</td>
 				<td>gauge</td>
 				<td>Holds number of currently pending flushes. See the related flush_limit_exceeded metric.</td>
@@ -703,7 +1007,7 @@
 			
 
 				<tr>
-				<td>80</td>
+				<td>118</td>
 				<td class="metric">scylla_commitlog_requests_blocked_memory</td>
 				<td>counter</td>
 				<td>Counts number of requests blocked due to memory pressure. A non-zero value indicates that the commitlog memory quota is not enough to serve the required amount of requests.</td>
@@ -711,7 +1015,7 @@
 			
 
 				<tr>
-				<td>81</td>
+				<td>119</td>
 				<td class="metric">scylla_commitlog_segments</td>
 				<td>gauge</td>
 				<td>Holds the current number of segments.</td>
@@ -719,7 +1023,7 @@
 			
 
 				<tr>
-				<td>82</td>
+				<td>120</td>
 				<td class="metric">scylla_commitlog_slack</td>
 				<td>counter</td>
 				<td>Counts number of unused bytes written to the disk due to disk segment alignment.</td>
@@ -727,7 +1031,7 @@
 			
 
 				<tr>
-				<td>83</td>
+				<td>121</td>
 				<td class="metric">scylla_commitlog_unused_segments</td>
 				<td>gauge</td>
 				<td>Holds the current number of unused segments. A non-zero value indicates that the disk write path became temporary slow.</td>
@@ -735,7 +1039,7 @@
 			
 
 				<tr>
-				<td>84</td>
+				<td>122</td>
 				<td class="metric">scylla_compaction_manager_backlog</td>
 				<td>gauge</td>
 				<td>Holds the sum of compaction backlog for all tables in the system.</td>
@@ -743,7 +1047,7 @@
 			
 
 				<tr>
-				<td>85</td>
+				<td>123</td>
 				<td class="metric">scylla_compaction_manager_compactions</td>
 				<td>gauge</td>
 				<td>Holds the number of currently active compactions.</td>
@@ -751,7 +1055,7 @@
 			
 
 				<tr>
-				<td>86</td>
+				<td>124</td>
 				<td class="metric">scylla_compaction_manager_completed_compactions</td>
 				<td>counter</td>
 				<td>Holds the number of completed compaction tasks.</td>
@@ -759,7 +1063,7 @@
 			
 
 				<tr>
-				<td>87</td>
+				<td>125</td>
 				<td class="metric">scylla_compaction_manager_failed_compactions</td>
 				<td>counter</td>
 				<td>Holds the number of failed compaction tasks.</td>
@@ -767,7 +1071,7 @@
 			
 
 				<tr>
-				<td>88</td>
+				<td>126</td>
 				<td class="metric">scylla_compaction_manager_normalized_backlog</td>
 				<td>gauge</td>
 				<td>Holds the sum of normalized compaction backlog for all tables in the system. Backlog is normalized by dividing backlog by shard's available memory.</td>
@@ -775,7 +1079,7 @@
 			
 
 				<tr>
-				<td>89</td>
+				<td>127</td>
 				<td class="metric">scylla_compaction_manager_pending_compactions</td>
 				<td>gauge</td>
 				<td>Holds the number of compaction tasks waiting for an opportunity to run.</td>
@@ -783,7 +1087,7 @@
 			
 
 				<tr>
-				<td>90</td>
+				<td>128</td>
 				<td class="metric">scylla_compaction_manager_postponed_compactions</td>
 				<td>gauge</td>
 				<td>Holds the number of tables with postponed compaction.</td>
@@ -791,7 +1095,7 @@
 			
 
 				<tr>
-				<td>91</td>
+				<td>129</td>
 				<td class="metric">scylla_compaction_manager_validation_errors</td>
 				<td>counter</td>
 				<td>Holds the number of encountered validation errors.</td>
@@ -799,7 +1103,7 @@
 			
 
 				<tr>
-				<td>92</td>
+				<td>130</td>
 				<td class="metric">scylla_cql_authorized_prepared_statements_cache_evictions</td>
 				<td>counter</td>
 				<td>Counts the number of authenticated prepared statements cache entries evictions.</td>
@@ -807,7 +1111,7 @@
 			
 
 				<tr>
-				<td>93</td>
+				<td>131</td>
 				<td class="metric">scylla_cql_authorized_prepared_statements_cache_size</td>
 				<td>gauge</td>
 				<td>Number of entries in the authenticated prepared statements cache.</td>
@@ -815,7 +1119,7 @@
 			
 
 				<tr>
-				<td>94</td>
+				<td>132</td>
 				<td class="metric">scylla_cql_authorized_prepared_statements_unprivileged_entries_evictions_on_size</td>
 				<td>counter</td>
 				<td>Counts a number of evictions of prepared statements from the authorized prepared statements cache after they have been used only once. An increasing counter suggests the user may be preparing a different statement for each request instead of reusing the same prepared statement with parameters.</td>
@@ -823,7 +1127,7 @@
 			
 
 				<tr>
-				<td>95</td>
+				<td>133</td>
 				<td class="metric">scylla_cql_batches</td>
 				<td>counter</td>
 				<td>Counts the total number of CQL BATCH requests without conditions.</td>
@@ -831,7 +1135,7 @@
 			
 
 				<tr>
-				<td>96</td>
+				<td>134</td>
 				<td class="metric">scylla_cql_batches_pure_logged</td>
 				<td>counter</td>
 				<td>Counts the total number of LOGGED batches that were executed as LOGGED batches.</td>
@@ -839,7 +1143,7 @@
 			
 
 				<tr>
-				<td>97</td>
+				<td>135</td>
 				<td class="metric">scylla_cql_batches_pure_unlogged</td>
 				<td>counter</td>
 				<td>Counts the total number of UNLOGGED batches that were executed as UNLOGGED batches.</td>
@@ -847,7 +1151,7 @@
 			
 
 				<tr>
-				<td>98</td>
+				<td>136</td>
 				<td class="metric">scylla_cql_batches_unlogged_from_logged</td>
 				<td>counter</td>
 				<td>Counts the total number of LOGGED batches that were executed as UNLOGGED batches.</td>
@@ -855,7 +1159,7 @@
 			
 
 				<tr>
-				<td>99</td>
+				<td>137</td>
 				<td class="metric">scylla_cql_deletes</td>
 				<td>counter</td>
 				<td>Counts the total number of CQL DELETE requests with/without conditions.</td>
@@ -863,7 +1167,7 @@
 			
 
 				<tr>
-				<td>100</td>
+				<td>138</td>
 				<td class="metric">scylla_cql_deletes_per_ks</td>
 				<td>counter</td>
 				<td>Counts the number of CQL DELETE requests executed on particular keyspaces. Label `who' indicates where the reqs come from (clients or DB internals)</td>
@@ -871,7 +1175,7 @@
 			
 
 				<tr>
-				<td>101</td>
+				<td>139</td>
 				<td class="metric">scylla_cql_filtered_read_requests</td>
 				<td>counter</td>
 				<td>Counts the total number of CQL read requests that required ALLOW FILTERING. See filtered_rows_read_total to compare how many rows needed to be filtered.</td>
@@ -879,7 +1183,7 @@
 			
 
 				<tr>
-				<td>102</td>
+				<td>140</td>
 				<td class="metric">scylla_cql_filtered_rows_dropped_total</td>
 				<td>counter</td>
 				<td>Counts the number of rows read during CQL requests that required ALLOW FILTERING and dropped by the filter. Number similar to filtered_rows_read_total indicates that filtering is not accurate and might cause performance degradation.</td>
@@ -887,7 +1191,7 @@
 			
 
 				<tr>
-				<td>103</td>
+				<td>141</td>
 				<td class="metric">scylla_cql_filtered_rows_matched_total</td>
 				<td>counter</td>
 				<td>Counts the number of rows read during CQL requests that required ALLOW FILTERING and accepted by the filter. Number similar to filtered_rows_read_total indicates that filtering is accurate.</td>
@@ -895,7 +1199,7 @@
 			
 
 				<tr>
-				<td>104</td>
+				<td>142</td>
 				<td class="metric">scylla_cql_filtered_rows_read_total</td>
 				<td>counter</td>
 				<td>Counts the total number of rows read during CQL requests that required ALLOW FILTERING. See filtered_rows_matched_total and filtered_rows_dropped_total for information how accurate filtering queries are.</td>
@@ -903,7 +1207,7 @@
 			
 
 				<tr>
-				<td>105</td>
+				<td>143</td>
 				<td class="metric">scylla_cql_inserts</td>
 				<td>counter</td>
 				<td>Counts the total number of CQL INSERT requests with/without conditions.</td>
@@ -911,7 +1215,7 @@
 			
 
 				<tr>
-				<td>106</td>
+				<td>144</td>
 				<td class="metric">scylla_cql_inserts_per_ks</td>
 				<td>counter</td>
 				<td>Counts the number of CQL INSERT requests executed on particular keyspaces. Label `who' indicates where the reqs come from (clients or DB internals).</td>
@@ -919,7 +1223,7 @@
 			
 
 				<tr>
-				<td>107</td>
+				<td>145</td>
 				<td class="metric">scylla_cql_prepared_cache_evictions</td>
 				<td>counter</td>
 				<td>Counts the number of prepared statements cache entries evictions.</td>
@@ -927,7 +1231,7 @@
 			
 
 				<tr>
-				<td>108</td>
+				<td>146</td>
 				<td class="metric">scylla_cql_prepared_cache_memory_footprint</td>
 				<td>gauge</td>
 				<td>Size (in bytes) of the prepared statements cache.</td>
@@ -935,7 +1239,7 @@
 			
 
 				<tr>
-				<td>109</td>
+				<td>147</td>
 				<td class="metric">scylla_cql_prepared_cache_size</td>
 				<td>gauge</td>
 				<td>A number of entries in the prepared statements cache.</td>
@@ -943,7 +1247,7 @@
 			
 
 				<tr>
-				<td>110</td>
+				<td>148</td>
 				<td class="metric">scylla_cql_reads</td>
 				<td>counter</td>
 				<td>Counts the total number of CQL SELECT requests.</td>
@@ -951,7 +1255,7 @@
 			
 
 				<tr>
-				<td>111</td>
+				<td>149</td>
 				<td class="metric">scylla_cql_reads_per_ks</td>
 				<td>counter</td>
 				<td>Counts the number of CQL SELECT requests executed on particular keyspaces. Label `who' indicates where the reqs come from (clients or DB internals)</td>
@@ -959,7 +1263,7 @@
 			
 
 				<tr>
-				<td>112</td>
+				<td>150</td>
 				<td class="metric">scylla_cql_reverse_queries</td>
 				<td>counter</td>
 				<td>Counts the number of CQL SELECT requests with reverse ORDER BY order.</td>
@@ -967,7 +1271,7 @@
 			
 
 				<tr>
-				<td>113</td>
+				<td>151</td>
 				<td class="metric">scylla_cql_rows_read</td>
 				<td>counter</td>
 				<td>Counts the total number of rows read during CQL requests.</td>
@@ -975,7 +1279,7 @@
 			
 
 				<tr>
-				<td>114</td>
+				<td>152</td>
 				<td class="metric">scylla_cql_secondary_index_creates</td>
 				<td>counter</td>
 				<td>Counts the total number of CQL CREATE INDEX requests.</td>
@@ -983,7 +1287,7 @@
 			
 
 				<tr>
-				<td>115</td>
+				<td>153</td>
 				<td class="metric">scylla_cql_secondary_index_drops</td>
 				<td>counter</td>
 				<td>Counts the total number of CQL DROP INDEX requests.</td>
@@ -991,7 +1295,7 @@
 			
 
 				<tr>
-				<td>116</td>
+				<td>154</td>
 				<td class="metric">scylla_cql_secondary_index_reads</td>
 				<td>counter</td>
 				<td>Counts the total number of CQL read requests performed using secondary indexes.</td>
@@ -999,7 +1303,7 @@
 			
 
 				<tr>
-				<td>117</td>
+				<td>155</td>
 				<td class="metric">scylla_cql_secondary_index_rows_read</td>
 				<td>counter</td>
 				<td>Counts the total number of rows read during CQL requests performed using secondary indexes.</td>
@@ -1007,7 +1311,7 @@
 			
 
 				<tr>
-				<td>118</td>
+				<td>156</td>
 				<td class="metric">scylla_cql_select_allow_filtering</td>
 				<td>counter</td>
 				<td>Counts the number of SELECT query executions with ALLOW FILTERING option.</td>
@@ -1015,7 +1319,7 @@
 			
 
 				<tr>
-				<td>119</td>
+				<td>157</td>
 				<td class="metric">scylla_cql_select_bypass_caches</td>
 				<td>counter</td>
 				<td>Counts the number of SELECT query executions with BYPASS CACHE option.</td>
@@ -1023,7 +1327,7 @@
 			
 
 				<tr>
-				<td>120</td>
+				<td>158</td>
 				<td class="metric">scylla_cql_select_parallelized</td>
 				<td>counter</td>
 				<td>Counts the number of parallelized aggregation SELECT query executions.</td>
@@ -1031,7 +1335,7 @@
 			
 
 				<tr>
-				<td>121</td>
+				<td>159</td>
 				<td class="metric">scylla_cql_select_partition_range_scan</td>
 				<td>counter</td>
 				<td>Counts the number of SELECT query executions requiring partition range scan.</td>
@@ -1039,7 +1343,7 @@
 			
 
 				<tr>
-				<td>122</td>
+				<td>160</td>
 				<td class="metric">scylla_cql_select_partition_range_scan_no_bypass_cache</td>
 				<td>counter</td>
 				<td>Counts the number of SELECT query executions requiring partition range scan without BYPASS CACHE option.</td>
@@ -1047,7 +1351,7 @@
 			
 
 				<tr>
-				<td>123</td>
+				<td>161</td>
 				<td class="metric">scylla_cql_statements_in_batches</td>
 				<td>counter</td>
 				<td>Counts the total number of sub-statements in CQL BATCH requests without conditions.</td>
@@ -1055,7 +1359,7 @@
 			
 
 				<tr>
-				<td>124</td>
+				<td>162</td>
 				<td class="metric">scylla_cql_unpaged_select_queries</td>
 				<td>counter</td>
 				<td>Counts the total number of unpaged CQL SELECT requests.</td>
@@ -1063,7 +1367,7 @@
 			
 
 				<tr>
-				<td>125</td>
+				<td>163</td>
 				<td class="metric">scylla_cql_unpaged_select_queries_per_ks</td>
 				<td>counter</td>
 				<td>Counts the number of unpaged CQL SELECT requests against particular keyspaces.</td>
@@ -1071,7 +1375,7 @@
 			
 
 				<tr>
-				<td>126</td>
+				<td>164</td>
 				<td class="metric">scylla_cql_unprivileged_entries_evictions_on_size</td>
 				<td>counter</td>
 				<td>Counts a number of evictions of prepared statements from the prepared statements cache after they have been used only once. An increasing counter suggests the user may be preparing a different statement for each request instead of reusing the same prepared statement with parameters.</td>
@@ -1079,7 +1383,7 @@
 			
 
 				<tr>
-				<td>127</td>
+				<td>165</td>
 				<td class="metric">scylla_cql_updates</td>
 				<td>counter</td>
 				<td>Counts the total number of CQL UPDATE requests with/without conditions.</td>
@@ -1087,7 +1391,7 @@
 			
 
 				<tr>
-				<td>128</td>
+				<td>166</td>
 				<td class="metric">scylla_cql_updates_per_ks</td>
 				<td>counter</td>
 				<td>Counts the number of CQL UPDATE requests executed on particular keyspaces. Label `who' indicates where the reqs come from (clients or DB internals)</td>
@@ -1095,7 +1399,7 @@
 			
 
 				<tr>
-				<td>129</td>
+				<td>167</td>
 				<td class="metric">scylla_cql_user_prepared_auth_cache_footprint</td>
 				<td>gauge</td>
 				<td>Size (in bytes) of the authenticated prepared statements cache.</td>
@@ -1103,7 +1407,7 @@
 			
 
 				<tr>
-				<td>130</td>
+				<td>168</td>
 				<td class="metric">scylla_database_active_reads</td>
 				<td>gauge</td>
 				<td>Holds the number of currently active read operations. </td>
@@ -1111,15 +1415,7 @@
 			
 
 				<tr>
-				<td>131</td>
-				<td class="metric">scylla_database_active_reads_memory_consumption</td>
-				<td>gauge</td>
-				<td>Holds the amount of memory consumed by currently active read operations. If this value gets close to 36700160 we are likely to start dropping new read requests. In that case sstable_read_queue_overloads is going to get a non-zero value.</td>
-				</tr>
-			
-
-				<tr>
-				<td>132</td>
+				<td>169</td>
 				<td class="metric">scylla_database_clustering_filter_count</td>
 				<td>counter</td>
 				<td>Counts bloom filter invocations.</td>
@@ -1127,7 +1423,7 @@
 			
 
 				<tr>
-				<td>133</td>
+				<td>170</td>
 				<td class="metric">scylla_database_clustering_filter_fast_path_count</td>
 				<td>counter</td>
 				<td>Counts number of times bloom filtering short cut to include all sstables when only one full range was specified.</td>
@@ -1135,7 +1431,7 @@
 			
 
 				<tr>
-				<td>134</td>
+				<td>171</td>
 				<td class="metric">scylla_database_clustering_filter_sstables_checked</td>
 				<td>counter</td>
 				<td>Counts sstables checked after applying the bloom filter. High value indicates that bloom filter is not very efficient.</td>
@@ -1143,7 +1439,7 @@
 			
 
 				<tr>
-				<td>135</td>
+				<td>172</td>
 				<td class="metric">scylla_database_clustering_filter_surviving_sstables</td>
 				<td>counter</td>
 				<td>Counts sstables that survived the clustering key filtering. High value indicates that bloom filter is not very efficient and still have to access a lot of sstables to get data.</td>
@@ -1151,7 +1447,7 @@
 			
 
 				<tr>
-				<td>136</td>
+				<td>173</td>
 				<td class="metric">scylla_database_counter_cell_lock_acquisition</td>
 				<td>counter</td>
 				<td>The number of acquired counter cell locks.</td>
@@ -1159,7 +1455,7 @@
 			
 
 				<tr>
-				<td>137</td>
+				<td>174</td>
 				<td class="metric">scylla_database_counter_cell_lock_pending</td>
 				<td>gauge</td>
 				<td>The number of counter updates waiting for a lock.</td>
@@ -1167,7 +1463,15 @@
 			
 
 				<tr>
-				<td>138</td>
+				<td>175</td>
+				<td class="metric">scylla_database_disk_reads</td>
+				<td>gauge</td>
+				<td>Holds the number of currently active disk read operations. </td>
+				</tr>
+			
+
+				<tr>
+				<td>176</td>
 				<td class="metric">scylla_database_dropped_view_updates</td>
 				<td>counter</td>
 				<td>Counts the number of view updates that have been dropped due to cluster overload. </td>
@@ -1175,7 +1479,7 @@
 			
 
 				<tr>
-				<td>139</td>
+				<td>177</td>
 				<td class="metric">scylla_database_large_partition_exceeding_threshold</td>
 				<td>counter</td>
 				<td>Number of large partitions exceeding compaction_large_partition_warning_threshold_mb. Large partitions have performance impact and should be avoided, check the documentation for details.</td>
@@ -1183,7 +1487,7 @@
 			
 
 				<tr>
-				<td>140</td>
+				<td>178</td>
 				<td class="metric">scylla_database_multishard_query_failed_reader_saves</td>
 				<td>counter</td>
 				<td>The number of times the saving of a shard reader failed.</td>
@@ -1191,7 +1495,7 @@
 			
 
 				<tr>
-				<td>141</td>
+				<td>179</td>
 				<td class="metric">scylla_database_multishard_query_failed_reader_stops</td>
 				<td>counter</td>
 				<td>The number of times the stopping of a shard reader failed.</td>
@@ -1199,7 +1503,7 @@
 			
 
 				<tr>
-				<td>142</td>
+				<td>180</td>
 				<td class="metric">scylla_database_multishard_query_unpopped_bytes</td>
 				<td>counter</td>
 				<td>The total number of bytes that were extracted from the shard reader but were unconsumed by the query and moved back into the reader.</td>
@@ -1207,7 +1511,7 @@
 			
 
 				<tr>
-				<td>143</td>
+				<td>181</td>
 				<td class="metric">scylla_database_multishard_query_unpopped_fragments</td>
 				<td>counter</td>
 				<td>The total number of fragments that were extracted from the shard reader but were unconsumed by the query and moved back into the reader.</td>
@@ -1215,7 +1519,7 @@
 			
 
 				<tr>
-				<td>144</td>
+				<td>182</td>
 				<td class="metric">scylla_database_paused_reads</td>
 				<td>gauge</td>
 				<td>The number of currently active reads that are temporarily paused.</td>
@@ -1223,7 +1527,7 @@
 			
 
 				<tr>
-				<td>145</td>
+				<td>183</td>
 				<td class="metric">scylla_database_paused_reads_permit_based_evictions</td>
 				<td>counter</td>
 				<td>The number of paused reads evicted to free up permits. Permits are required for new reads to start, and the database will evict paused reads (if any) to be able to admit new ones, if there is a shortage of permits.</td>
@@ -1231,15 +1535,15 @@
 			
 
 				<tr>
-				<td>146</td>
+				<td>184</td>
 				<td class="metric">scylla_database_querier_cache_drops</td>
 				<td>counter</td>
-				<td>Counts querier cache lookups that found a cached querier but had to drop it due to position mismatch</td>
+				<td>Counts querier cache lookups that found a cached querier but had to drop it</td>
 				</tr>
 			
 
 				<tr>
-				<td>147</td>
+				<td>185</td>
 				<td class="metric">scylla_database_querier_cache_lookups</td>
 				<td>counter</td>
 				<td>Counts querier cache lookups (paging queries)</td>
@@ -1247,7 +1551,7 @@
 			
 
 				<tr>
-				<td>148</td>
+				<td>186</td>
 				<td class="metric">scylla_database_querier_cache_misses</td>
 				<td>counter</td>
 				<td>Counts querier cache lookups that failed to find a cached querier</td>
@@ -1255,7 +1559,7 @@
 			
 
 				<tr>
-				<td>149</td>
+				<td>187</td>
 				<td class="metric">scylla_database_querier_cache_population</td>
 				<td>gauge</td>
 				<td>The number of entries currently in the querier cache.</td>
@@ -1263,7 +1567,7 @@
 			
 
 				<tr>
-				<td>150</td>
+				<td>188</td>
 				<td class="metric">scylla_database_querier_cache_resource_based_evictions</td>
 				<td>counter</td>
 				<td>Counts querier cache entries that were evicted to free up resources (limited by reader concurency limits) necessary to create new readers.</td>
@@ -1271,7 +1575,15 @@
 			
 
 				<tr>
-				<td>151</td>
+				<td>189</td>
+				<td class="metric">scylla_database_querier_cache_scheduling_group_mismatches</td>
+				<td>counter</td>
+				<td>Counts querier cache lookups that found a cached querier but had to drop it due to scheduling group mismatch</td>
+				</tr>
+			
+
+				<tr>
+				<td>190</td>
 				<td class="metric">scylla_database_querier_cache_time_based_evictions</td>
 				<td>counter</td>
 				<td>Counts querier cache entries that timed out and were evicted.</td>
@@ -1279,7 +1591,7 @@
 			
 
 				<tr>
-				<td>152</td>
+				<td>191</td>
 				<td class="metric">scylla_database_queued_reads</td>
 				<td>gauge</td>
 				<td>Holds the number of currently queued read operations.</td>
@@ -1287,7 +1599,15 @@
 			
 
 				<tr>
-				<td>153</td>
+				<td>192</td>
+				<td class="metric">scylla_database_reads_memory_consumption</td>
+				<td>gauge</td>
+				<td>Holds the amount of memory consumed by current read operations. </td>
+				</tr>
+			
+
+				<tr>
+				<td>193</td>
 				<td class="metric">scylla_database_reads_shed_due_to_overload</td>
 				<td>counter</td>
 				<td>The number of reads shed because the admission queue reached its max capacity. When the queue is full, excessive reads are shed to avoid overload.</td>
@@ -1295,23 +1615,23 @@
 			
 
 				<tr>
-				<td>154</td>
+				<td>194</td>
 				<td class="metric">scylla_database_requests_blocked_memory</td>
 				<td>counter</td>
-				<td>Holds the current number of requests blocked due to reaching the memory quota (458752000B). Non-zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the "database" component.</td>
+				<td>Holds the current number of requests blocked due to reaching the memory quota (444596224B). Non-zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the "database" component.</td>
 				</tr>
 			
 
 				<tr>
-				<td>155</td>
+				<td>195</td>
 				<td class="metric">scylla_database_requests_blocked_memory_current</td>
 				<td>gauge</td>
-				<td>Holds the current number of requests blocked due to reaching the memory quota (458752000B). Non-zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the "database" component.</td>
+				<td>Holds the current number of requests blocked due to reaching the memory quota (444596224B). Non-zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the "database" component.</td>
 				</tr>
 			
 
 				<tr>
-				<td>156</td>
+				<td>196</td>
 				<td class="metric">scylla_database_schema_changed</td>
 				<td>counter</td>
 				<td>The number of times the schema changed</td>
@@ -1319,7 +1639,7 @@
 			
 
 				<tr>
-				<td>157</td>
+				<td>197</td>
 				<td class="metric">scylla_database_short_data_queries</td>
 				<td>counter</td>
 				<td>The rate of data queries (data or digest reads) that returned less rows than requested due to result size limiting.</td>
@@ -1327,7 +1647,7 @@
 			
 
 				<tr>
-				<td>158</td>
+				<td>198</td>
 				<td class="metric">scylla_database_short_mutation_queries</td>
 				<td>counter</td>
 				<td>The rate of mutation queries that returned less rows than requested due to result size limiting.</td>
@@ -1335,7 +1655,7 @@
 			
 
 				<tr>
-				<td>159</td>
+				<td>199</td>
 				<td class="metric">scylla_database_sstable_read_queue_overloads</td>
 				<td>counter</td>
 				<td>Counts the number of times the sstable read queue was overloaded. A non-zero value indicates that we have to drop read requests because they arrive faster than we can serve them.</td>
@@ -1343,7 +1663,15 @@
 			
 
 				<tr>
-				<td>160</td>
+				<td>200</td>
+				<td class="metric">scylla_database_sstables_read</td>
+				<td>gauge</td>
+				<td>Holds the number of currently read sstables. </td>
+				</tr>
+			
+
+				<tr>
+				<td>201</td>
 				<td class="metric">scylla_database_total_reads</td>
 				<td>counter</td>
 				<td>Counts the total number of successful user reads on this shard.</td>
@@ -1351,7 +1679,7 @@
 			
 
 				<tr>
-				<td>161</td>
+				<td>202</td>
 				<td class="metric">scylla_database_total_reads_failed</td>
 				<td>counter</td>
 				<td>Counts the total number of failed user read operations. Add the total_reads to this value to get the total amount of reads issued on this shard.</td>
@@ -1359,7 +1687,7 @@
 			
 
 				<tr>
-				<td>162</td>
+				<td>203</td>
 				<td class="metric">scylla_database_total_reads_rate_limited</td>
 				<td>counter</td>
 				<td>Counts read operations which were rejected on the replica side because the per-partition limit was reached.</td>
@@ -1367,7 +1695,7 @@
 			
 
 				<tr>
-				<td>163</td>
+				<td>204</td>
 				<td class="metric">scylla_database_total_result_bytes</td>
 				<td>gauge</td>
 				<td>Holds the current amount of memory used for results.</td>
@@ -1375,7 +1703,7 @@
 			
 
 				<tr>
-				<td>164</td>
+				<td>205</td>
 				<td class="metric">scylla_database_total_view_updates_failed_local</td>
 				<td>counter</td>
 				<td>Total number of view updates generated for tables and failed to be applied locally.</td>
@@ -1383,7 +1711,7 @@
 			
 
 				<tr>
-				<td>165</td>
+				<td>206</td>
 				<td class="metric">scylla_database_total_view_updates_failed_remote</td>
 				<td>counter</td>
 				<td>Total number of view updates generated for tables and failed to be sent to remote replicas.</td>
@@ -1391,7 +1719,7 @@
 			
 
 				<tr>
-				<td>166</td>
+				<td>207</td>
 				<td class="metric">scylla_database_total_view_updates_pushed_local</td>
 				<td>counter</td>
 				<td>Total number of view updates generated for tables and applied locally.</td>
@@ -1399,7 +1727,7 @@
 			
 
 				<tr>
-				<td>167</td>
+				<td>208</td>
 				<td class="metric">scylla_database_total_view_updates_pushed_remote</td>
 				<td>counter</td>
 				<td>Total number of view updates generated for tables and sent to remote replicas.</td>
@@ -1407,7 +1735,7 @@
 			
 
 				<tr>
-				<td>168</td>
+				<td>209</td>
 				<td class="metric">scylla_database_total_writes</td>
 				<td>counter</td>
 				<td>Counts the total number of successful write operations performed by this shard.</td>
@@ -1415,7 +1743,7 @@
 			
 
 				<tr>
-				<td>169</td>
+				<td>210</td>
 				<td class="metric">scylla_database_total_writes_failed</td>
 				<td>counter</td>
 				<td>Counts the total number of failed write operations. A sum of this value plus total_writes represents a total amount of writes attempted on this shard.</td>
@@ -1423,7 +1751,7 @@
 			
 
 				<tr>
-				<td>170</td>
+				<td>211</td>
 				<td class="metric">scylla_database_total_writes_rate_limited</td>
 				<td>counter</td>
 				<td>Counts write operations which were rejected on the replica side because the per-partition limit was reached.</td>
@@ -1431,7 +1759,7 @@
 			
 
 				<tr>
-				<td>171</td>
+				<td>212</td>
 				<td class="metric">scylla_database_total_writes_timedout</td>
 				<td>counter</td>
 				<td>Counts write operations failed due to a timeout. A positive value is a sign of storage being overloaded.</td>
@@ -1439,7 +1767,7 @@
 			
 
 				<tr>
-				<td>172</td>
+				<td>213</td>
 				<td class="metric">scylla_database_view_building_paused</td>
 				<td>counter</td>
 				<td>Counts the number of times view building process was paused (e.g. due to node unavailability). </td>
@@ -1447,7 +1775,7 @@
 			
 
 				<tr>
-				<td>173</td>
+				<td>214</td>
 				<td class="metric">scylla_database_view_update_backlog</td>
 				<td>gauge</td>
 				<td>Holds the current size in bytes of the pending view updates for all tables</td>
@@ -1455,7 +1783,7 @@
 			
 
 				<tr>
-				<td>174</td>
+				<td>215</td>
 				<td class="metric">scylla_execution_stages_function_calls_enqueued</td>
 				<td>counter</td>
 				<td>Counts function calls added to execution stages queues</td>
@@ -1463,7 +1791,7 @@
 			
 
 				<tr>
-				<td>175</td>
+				<td>216</td>
 				<td class="metric">scylla_execution_stages_function_calls_executed</td>
 				<td>counter</td>
 				<td>Counts function calls executed by execution stages</td>
@@ -1471,7 +1799,7 @@
 			
 
 				<tr>
-				<td>176</td>
+				<td>217</td>
 				<td class="metric">scylla_execution_stages_tasks_preempted</td>
 				<td>counter</td>
 				<td>Counts tasks which were preempted before execution all queued operations</td>
@@ -1479,7 +1807,7 @@
 			
 
 				<tr>
-				<td>177</td>
+				<td>218</td>
 				<td class="metric">scylla_execution_stages_tasks_scheduled</td>
 				<td>counter</td>
 				<td>Counts tasks scheduled by execution stages</td>
@@ -1487,7 +1815,7 @@
 			
 
 				<tr>
-				<td>178</td>
+				<td>219</td>
 				<td class="metric">scylla_forward_service_requests_dispatched_to_other_nodes</td>
 				<td>counter</td>
 				<td>how many forward requests were dispatched to other nodes</td>
@@ -1495,7 +1823,7 @@
 			
 
 				<tr>
-				<td>179</td>
+				<td>220</td>
 				<td class="metric">scylla_forward_service_requests_dispatched_to_own_shards</td>
 				<td>counter</td>
 				<td>how many forward requests were dispatched to local shards</td>
@@ -1503,7 +1831,7 @@
 			
 
 				<tr>
-				<td>180</td>
+				<td>221</td>
 				<td class="metric">scylla_forward_service_requests_executed</td>
 				<td>counter</td>
 				<td>how many forward requests were executed</td>
@@ -1511,7 +1839,7 @@
 			
 
 				<tr>
-				<td>181</td>
+				<td>222</td>
 				<td class="metric">scylla_gossip_heart_beat</td>
 				<td>counter</td>
 				<td>Heartbeat of the current Node.</td>
@@ -1519,7 +1847,7 @@
 			
 
 				<tr>
-				<td>182</td>
+				<td>223</td>
 				<td class="metric">scylla_gossip_live</td>
 				<td>gauge</td>
 				<td>How many live nodes the current node sees</td>
@@ -1527,7 +1855,7 @@
 			
 
 				<tr>
-				<td>183</td>
+				<td>224</td>
 				<td class="metric">scylla_gossip_unreachable</td>
 				<td>gauge</td>
 				<td>How many unreachable nodes the current node sees</td>
@@ -1535,7 +1863,7 @@
 			
 
 				<tr>
-				<td>184</td>
+				<td>225</td>
 				<td class="metric">scylla_hints_for_views_manager_corrupted_files</td>
 				<td>counter</td>
 				<td>Number of hints files that were discarded during sending because the file was corrupted.</td>
@@ -1543,7 +1871,7 @@
 			
 
 				<tr>
-				<td>185</td>
+				<td>226</td>
 				<td class="metric">scylla_hints_for_views_manager_discarded</td>
 				<td>counter</td>
 				<td>Number of hints that were discarded during sending (too old, schema changed, etc.).</td>
@@ -1551,7 +1879,7 @@
 			
 
 				<tr>
-				<td>186</td>
+				<td>227</td>
 				<td class="metric">scylla_hints_for_views_manager_dropped</td>
 				<td>counter</td>
 				<td>Number of dropped hints.</td>
@@ -1559,7 +1887,7 @@
 			
 
 				<tr>
-				<td>187</td>
+				<td>228</td>
 				<td class="metric">scylla_hints_for_views_manager_errors</td>
 				<td>counter</td>
 				<td>Number of errors during hints writes.</td>
@@ -1567,7 +1895,7 @@
 			
 
 				<tr>
-				<td>188</td>
+				<td>229</td>
 				<td class="metric">scylla_hints_for_views_manager_pending_drains</td>
 				<td>gauge</td>
 				<td>Number of tasks waiting in the queue for draining hints</td>
@@ -1575,7 +1903,7 @@
 			
 
 				<tr>
-				<td>189</td>
+				<td>230</td>
 				<td class="metric">scylla_hints_for_views_manager_pending_sends</td>
 				<td>gauge</td>
 				<td>Number of tasks waiting in the queue for sending a hint</td>
@@ -1583,7 +1911,7 @@
 			
 
 				<tr>
-				<td>190</td>
+				<td>231</td>
 				<td class="metric">scylla_hints_for_views_manager_sent</td>
 				<td>counter</td>
 				<td>Number of sent hints.</td>
@@ -1591,7 +1919,7 @@
 			
 
 				<tr>
-				<td>191</td>
+				<td>232</td>
 				<td class="metric">scylla_hints_for_views_manager_size_of_hints_in_progress</td>
 				<td>gauge</td>
 				<td>Size of hinted mutations that are scheduled to be written.</td>
@@ -1599,7 +1927,7 @@
 			
 
 				<tr>
-				<td>192</td>
+				<td>233</td>
 				<td class="metric">scylla_hints_for_views_manager_written</td>
 				<td>counter</td>
 				<td>Number of successfully written hints.</td>
@@ -1607,7 +1935,7 @@
 			
 
 				<tr>
-				<td>193</td>
+				<td>234</td>
 				<td class="metric">scylla_hints_manager_corrupted_files</td>
 				<td>counter</td>
 				<td>Number of hints files that were discarded during sending because the file was corrupted.</td>
@@ -1615,7 +1943,7 @@
 			
 
 				<tr>
-				<td>194</td>
+				<td>235</td>
 				<td class="metric">scylla_hints_manager_discarded</td>
 				<td>counter</td>
 				<td>Number of hints that were discarded during sending (too old, schema changed, etc.).</td>
@@ -1623,7 +1951,7 @@
 			
 
 				<tr>
-				<td>195</td>
+				<td>236</td>
 				<td class="metric">scylla_hints_manager_dropped</td>
 				<td>counter</td>
 				<td>Number of dropped hints.</td>
@@ -1631,7 +1959,7 @@
 			
 
 				<tr>
-				<td>196</td>
+				<td>237</td>
 				<td class="metric">scylla_hints_manager_errors</td>
 				<td>counter</td>
 				<td>Number of errors during hints writes.</td>
@@ -1639,7 +1967,7 @@
 			
 
 				<tr>
-				<td>197</td>
+				<td>238</td>
 				<td class="metric">scylla_hints_manager_pending_drains</td>
 				<td>gauge</td>
 				<td>Number of tasks waiting in the queue for draining hints</td>
@@ -1647,7 +1975,7 @@
 			
 
 				<tr>
-				<td>198</td>
+				<td>239</td>
 				<td class="metric">scylla_hints_manager_pending_sends</td>
 				<td>gauge</td>
 				<td>Number of tasks waiting in the queue for sending a hint</td>
@@ -1655,7 +1983,7 @@
 			
 
 				<tr>
-				<td>199</td>
+				<td>240</td>
 				<td class="metric">scylla_hints_manager_sent</td>
 				<td>counter</td>
 				<td>Number of sent hints.</td>
@@ -1663,7 +1991,7 @@
 			
 
 				<tr>
-				<td>200</td>
+				<td>241</td>
 				<td class="metric">scylla_hints_manager_size_of_hints_in_progress</td>
 				<td>gauge</td>
 				<td>Size of hinted mutations that are scheduled to be written.</td>
@@ -1671,7 +1999,7 @@
 			
 
 				<tr>
-				<td>201</td>
+				<td>242</td>
 				<td class="metric">scylla_hints_manager_written</td>
 				<td>counter</td>
 				<td>Number of successfully written hints.</td>
@@ -1679,7 +2007,7 @@
 			
 
 				<tr>
-				<td>202</td>
+				<td>243</td>
 				<td class="metric">scylla_httpd_connections_current</td>
 				<td>gauge</td>
 				<td>The current number of open  connections</td>
@@ -1687,7 +2015,7 @@
 			
 
 				<tr>
-				<td>203</td>
+				<td>244</td>
 				<td class="metric">scylla_httpd_connections_total</td>
 				<td>counter</td>
 				<td>The total number of connections opened</td>
@@ -1695,7 +2023,7 @@
 			
 
 				<tr>
-				<td>204</td>
+				<td>245</td>
 				<td class="metric">scylla_httpd_read_errors</td>
 				<td>counter</td>
 				<td>The total number of errors while reading http requests</td>
@@ -1703,7 +2031,7 @@
 			
 
 				<tr>
-				<td>205</td>
+				<td>246</td>
 				<td class="metric">scylla_httpd_reply_errors</td>
 				<td>counter</td>
 				<td>The total number of errors while replying to http</td>
@@ -1711,7 +2039,7 @@
 			
 
 				<tr>
-				<td>206</td>
+				<td>247</td>
 				<td class="metric">scylla_httpd_requests_served</td>
 				<td>counter</td>
 				<td>The total number of http requests served</td>
@@ -1719,7 +2047,7 @@
 			
 
 				<tr>
-				<td>207</td>
+				<td>248</td>
 				<td class="metric">scylla_io_queue_adjusted_consumption</td>
 				<td>counter</td>
 				<td>Consumed disk capacity units adjusted for class shares and idling preemption</td>
@@ -1727,7 +2055,7 @@
 			
 
 				<tr>
-				<td>208</td>
+				<td>249</td>
 				<td class="metric">scylla_io_queue_consumption</td>
 				<td>counter</td>
 				<td>Accumulated disk capacity units consumed by this class; an increment per-second rate indicates full utilization</td>
@@ -1735,7 +2063,7 @@
 			
 
 				<tr>
-				<td>209</td>
+				<td>250</td>
 				<td class="metric">scylla_io_queue_delay</td>
 				<td>gauge</td>
 				<td>random delay time in the queue</td>
@@ -1743,7 +2071,7 @@
 			
 
 				<tr>
-				<td>210</td>
+				<td>251</td>
 				<td class="metric">scylla_io_queue_disk_queue_length</td>
 				<td>gauge</td>
 				<td>Number of requests in the disk</td>
@@ -1751,7 +2079,7 @@
 			
 
 				<tr>
-				<td>211</td>
+				<td>252</td>
 				<td class="metric">scylla_io_queue_queue_length</td>
 				<td>gauge</td>
 				<td>Number of requests in the queue</td>
@@ -1759,7 +2087,7 @@
 			
 
 				<tr>
-				<td>212</td>
+				<td>253</td>
 				<td class="metric">scylla_io_queue_shares</td>
 				<td>gauge</td>
 				<td>current amount of shares</td>
@@ -1767,7 +2095,7 @@
 			
 
 				<tr>
-				<td>213</td>
+				<td>254</td>
 				<td class="metric">scylla_io_queue_starvation_time_sec</td>
 				<td>counter</td>
 				<td>Total time spent starving for disk</td>
@@ -1775,7 +2103,7 @@
 			
 
 				<tr>
-				<td>214</td>
+				<td>255</td>
 				<td class="metric">scylla_io_queue_total_bytes</td>
 				<td>counter</td>
 				<td>Total bytes passed in the queue</td>
@@ -1783,7 +2111,7 @@
 			
 
 				<tr>
-				<td>215</td>
+				<td>256</td>
 				<td class="metric">scylla_io_queue_total_delay_sec</td>
 				<td>counter</td>
 				<td>Total time spent in the queue</td>
@@ -1791,7 +2119,7 @@
 			
 
 				<tr>
-				<td>216</td>
+				<td>257</td>
 				<td class="metric">scylla_io_queue_total_exec_sec</td>
 				<td>counter</td>
 				<td>Total time spent in disk</td>
@@ -1799,7 +2127,7 @@
 			
 
 				<tr>
-				<td>217</td>
+				<td>258</td>
 				<td class="metric">scylla_io_queue_total_operations</td>
 				<td>counter</td>
 				<td>Total operations passed in the queue</td>
@@ -1807,7 +2135,7 @@
 			
 
 				<tr>
-				<td>218</td>
+				<td>259</td>
 				<td class="metric">scylla_io_queue_total_read_bytes</td>
 				<td>counter</td>
 				<td>Total read bytes passed in the queue</td>
@@ -1815,7 +2143,7 @@
 			
 
 				<tr>
-				<td>219</td>
+				<td>260</td>
 				<td class="metric">scylla_io_queue_total_read_ops</td>
 				<td>counter</td>
 				<td>Total read operations passed in the queue</td>
@@ -1823,7 +2151,7 @@
 			
 
 				<tr>
-				<td>220</td>
+				<td>261</td>
 				<td class="metric">scylla_io_queue_total_split_bytes</td>
 				<td>counter</td>
 				<td>Total number of bytes split</td>
@@ -1831,7 +2159,7 @@
 			
 
 				<tr>
-				<td>221</td>
+				<td>262</td>
 				<td class="metric">scylla_io_queue_total_split_ops</td>
 				<td>counter</td>
 				<td>Total number of requests split</td>
@@ -1839,7 +2167,7 @@
 			
 
 				<tr>
-				<td>222</td>
+				<td>263</td>
 				<td class="metric">scylla_io_queue_total_write_bytes</td>
 				<td>counter</td>
 				<td>Total write bytes passed in the queue</td>
@@ -1847,7 +2175,7 @@
 			
 
 				<tr>
-				<td>223</td>
+				<td>264</td>
 				<td class="metric">scylla_io_queue_total_write_ops</td>
 				<td>counter</td>
 				<td>Total write operations passed in the queue</td>
@@ -1855,7 +2183,7 @@
 			
 
 				<tr>
-				<td>224</td>
+				<td>265</td>
 				<td class="metric">scylla_lsa_free_space</td>
 				<td>gauge</td>
 				<td>Holds a current amount of free memory that is under lsa control.</td>
@@ -1863,7 +2191,7 @@
 			
 
 				<tr>
-				<td>225</td>
+				<td>266</td>
 				<td class="metric">scylla_lsa_large_objects_total_space_bytes</td>
 				<td>gauge</td>
 				<td>Holds a current size of allocated non-LSA memory.</td>
@@ -1871,7 +2199,7 @@
 			
 
 				<tr>
-				<td>226</td>
+				<td>267</td>
 				<td class="metric">scylla_lsa_memory_allocated</td>
 				<td>counter</td>
 				<td>Counts number of bytes which were requested from LSA.</td>
@@ -1879,7 +2207,7 @@
 			
 
 				<tr>
-				<td>227</td>
+				<td>268</td>
 				<td class="metric">scylla_lsa_memory_compacted</td>
 				<td>counter</td>
 				<td>Counts number of bytes which were copied as part of segment compaction.</td>
@@ -1887,7 +2215,7 @@
 			
 
 				<tr>
-				<td>228</td>
+				<td>269</td>
 				<td class="metric">scylla_lsa_memory_evicted</td>
 				<td>counter</td>
 				<td>Counts number of bytes which were evicted.</td>
@@ -1895,7 +2223,7 @@
 			
 
 				<tr>
-				<td>229</td>
+				<td>270</td>
 				<td class="metric">scylla_lsa_memory_freed</td>
 				<td>counter</td>
 				<td>Counts number of bytes which were requested to be freed in LSA.</td>
@@ -1903,7 +2231,7 @@
 			
 
 				<tr>
-				<td>230</td>
+				<td>271</td>
 				<td class="metric">scylla_lsa_non_lsa_used_space_bytes</td>
 				<td>gauge</td>
 				<td>Holds a current amount of used non-LSA memory.</td>
@@ -1911,7 +2239,7 @@
 			
 
 				<tr>
-				<td>231</td>
+				<td>272</td>
 				<td class="metric">scylla_lsa_occupancy</td>
 				<td>gauge</td>
 				<td>Holds a current portion (in percents) of the used memory.</td>
@@ -1919,7 +2247,7 @@
 			
 
 				<tr>
-				<td>232</td>
+				<td>273</td>
 				<td class="metric">scylla_lsa_segments_compacted</td>
 				<td>counter</td>
 				<td>Counts a number of compacted segments.</td>
@@ -1927,7 +2255,7 @@
 			
 
 				<tr>
-				<td>233</td>
+				<td>274</td>
 				<td class="metric">scylla_lsa_small_objects_total_space_bytes</td>
 				<td>gauge</td>
 				<td>Holds a current size of "small objects" memory region in bytes.</td>
@@ -1935,7 +2263,7 @@
 			
 
 				<tr>
-				<td>234</td>
+				<td>275</td>
 				<td class="metric">scylla_lsa_small_objects_used_space_bytes</td>
 				<td>gauge</td>
 				<td>Holds a current amount of used "small objects" memory in bytes.</td>
@@ -1943,7 +2271,7 @@
 			
 
 				<tr>
-				<td>235</td>
+				<td>276</td>
 				<td class="metric">scylla_lsa_total_space_bytes</td>
 				<td>gauge</td>
 				<td>Holds a current size of allocated memory in bytes.</td>
@@ -1951,7 +2279,7 @@
 			
 
 				<tr>
-				<td>236</td>
+				<td>277</td>
 				<td class="metric">scylla_lsa_used_space_bytes</td>
 				<td>gauge</td>
 				<td>Holds a current amount of used memory in bytes.</td>
@@ -1959,7 +2287,7 @@
 			
 
 				<tr>
-				<td>237</td>
+				<td>278</td>
 				<td class="metric">scylla_memory_allocated_memory</td>
 				<td>gauge</td>
 				<td>Allocated memory size in bytes</td>
@@ -1967,7 +2295,7 @@
 			
 
 				<tr>
-				<td>238</td>
+				<td>279</td>
 				<td class="metric">scylla_memory_cross_cpu_free_operations</td>
 				<td>counter</td>
 				<td>Total number of cross cpu free</td>
@@ -1975,15 +2303,15 @@
 			
 
 				<tr>
-				<td>239</td>
+				<td>280</td>
 				<td class="metric">scylla_memory_dirty_bytes</td>
 				<td>gauge</td>
-				<td>Holds the current size of all ("regular", "system" and "streaming") non-free memory in bytes: used memory + released memory that hasn't been returned to a free memory pool yet. Total memory size minus this value represents the amount of available memory. If this value minus virtual_dirty_bytes is too high then this means that the dirty memory eviction lags behind.</td>
+				<td>Holds the current size of all ("regular", "system" and "streaming") non-free memory in bytes: used memory + released memory that hasn't been returned to a free memory pool yet. Total memory size minus this value represents the amount of available memory. If this value minus unspooled_dirty_bytes is too high then this means that the dirty memory eviction lags behind.</td>
 				</tr>
 			
 
 				<tr>
-				<td>240</td>
+				<td>281</td>
 				<td class="metric">scylla_memory_free_memory</td>
 				<td>gauge</td>
 				<td>Free memory size in bytes</td>
@@ -1991,7 +2319,7 @@
 			
 
 				<tr>
-				<td>241</td>
+				<td>282</td>
 				<td class="metric">scylla_memory_free_operations</td>
 				<td>counter</td>
 				<td>Total number of free operations</td>
@@ -1999,7 +2327,15 @@
 			
 
 				<tr>
-				<td>242</td>
+				<td>283</td>
+				<td class="metric">scylla_memory_malloc_failed</td>
+				<td>counter</td>
+				<td>Total count of failed memory allocations</td>
+				</tr>
+			
+
+				<tr>
+				<td>284</td>
 				<td class="metric">scylla_memory_malloc_live_objects</td>
 				<td>gauge</td>
 				<td>Number of live objects</td>
@@ -2007,7 +2343,7 @@
 			
 
 				<tr>
-				<td>243</td>
+				<td>285</td>
 				<td class="metric">scylla_memory_malloc_operations</td>
 				<td>counter</td>
 				<td>Total number of malloc operations</td>
@@ -2015,7 +2351,7 @@
 			
 
 				<tr>
-				<td>244</td>
+				<td>286</td>
 				<td class="metric">scylla_memory_reclaims_operations</td>
 				<td>counter</td>
 				<td>Total reclaims operations</td>
@@ -2023,39 +2359,39 @@
 			
 
 				<tr>
-				<td>245</td>
+				<td>287</td>
 				<td class="metric">scylla_memory_regular_dirty_bytes</td>
 				<td>gauge</td>
-				<td>Holds the current size of a all non-free memory in bytes: used memory + released memory that hasn't been returned to a free memory pool yet. Total memory size minus this value represents the amount of available memory. If this value minus virtual_dirty_bytes is too high then this means that the dirty memory eviction lags behind.</td>
+				<td>Holds the current size of a all non-free memory in bytes: used memory + released memory that hasn't been returned to a free memory pool yet. Total memory size minus this value represents the amount of available memory. If this value minus unspooled_dirty_bytes is too high then this means that the dirty memory eviction lags behind.</td>
 				</tr>
 			
 
 				<tr>
-				<td>246</td>
-				<td class="metric">scylla_memory_regular_virtual_dirty_bytes</td>
+				<td>288</td>
+				<td class="metric">scylla_memory_regular_unspooled_dirty_bytes</td>
 				<td>gauge</td>
 				<td>Holds the size of used memory in bytes. Compare it to "dirty_bytes" to see how many memory is wasted (neither used nor available).</td>
 				</tr>
 			
 
 				<tr>
-				<td>247</td>
+				<td>289</td>
 				<td class="metric">scylla_memory_system_dirty_bytes</td>
 				<td>gauge</td>
-				<td>Holds the current size of a all non-free memory in bytes: used memory + released memory that hasn't been returned to a free memory pool yet. Total memory size minus this value represents the amount of available memory. If this value minus virtual_dirty_bytes is too high then this means that the dirty memory eviction lags behind.</td>
+				<td>Holds the current size of a all non-free memory in bytes: used memory + released memory that hasn't been returned to a free memory pool yet. Total memory size minus this value represents the amount of available memory. If this value minus unspooled_dirty_bytes is too high then this means that the dirty memory eviction lags behind.</td>
 				</tr>
 			
 
 				<tr>
-				<td>248</td>
-				<td class="metric">scylla_memory_system_virtual_dirty_bytes</td>
+				<td>290</td>
+				<td class="metric">scylla_memory_system_unspooled_dirty_bytes</td>
 				<td>gauge</td>
 				<td>Holds the size of used memory in bytes. Compare it to "dirty_bytes" to see how many memory is wasted (neither used nor available).</td>
 				</tr>
 			
 
 				<tr>
-				<td>249</td>
+				<td>291</td>
 				<td class="metric">scylla_memory_total_memory</td>
 				<td>gauge</td>
 				<td>Total memory size in bytes</td>
@@ -2063,15 +2399,15 @@
 			
 
 				<tr>
-				<td>250</td>
-				<td class="metric">scylla_memory_virtual_dirty_bytes</td>
+				<td>292</td>
+				<td class="metric">scylla_memory_unspooled_dirty_bytes</td>
 				<td>gauge</td>
 				<td>Holds the size of all ("regular", "system" and "streaming") used memory in bytes. Compare it to "dirty_bytes" to see how many memory is wasted (neither used nor available).</td>
 				</tr>
 			
 
 				<tr>
-				<td>251</td>
+				<td>293</td>
 				<td class="metric">scylla_memtables_failed_flushes</td>
 				<td>gauge</td>
 				<td>Holds the number of failed memtable flushes. High value in this metric may indicate a permanent failure to flush a memtable.</td>
@@ -2079,7 +2415,7 @@
 			
 
 				<tr>
-				<td>252</td>
+				<td>294</td>
 				<td class="metric">scylla_memtables_pending_flushes</td>
 				<td>gauge</td>
 				<td>Holds the current number of memtables that are currently being flushed to sstables. High value in this metric may be an indication of storage being a bottleneck.</td>
@@ -2087,7 +2423,7 @@
 			
 
 				<tr>
-				<td>253</td>
+				<td>295</td>
 				<td class="metric">scylla_memtables_pending_flushes_bytes</td>
 				<td>gauge</td>
 				<td>Holds the current number of bytes in memtables that are currently being flushed to sstables. High value in this metric may be an indication of storage being a bottleneck.</td>
@@ -2095,7 +2431,7 @@
 			
 
 				<tr>
-				<td>254</td>
+				<td>296</td>
 				<td class="metric">scylla_node_operation_mode</td>
 				<td>gauge</td>
 				<td>The operation mode of the current node. UNKNOWN = 0, STARTING = 1, JOINING = 2, NORMAL = 3, LEAVING = 4, DECOMMISSIONED = 5, DRAINING = 6, DRAINED = 7, MOVING = 8</td>
@@ -2103,7 +2439,7 @@
 			
 
 				<tr>
-				<td>255</td>
+				<td>297</td>
 				<td class="metric">scylla_node_ops_finished_percentage</td>
 				<td>gauge</td>
 				<td>Finished percentage of node operation on this shard</td>
@@ -2111,7 +2447,7 @@
 			
 
 				<tr>
-				<td>256</td>
+				<td>298</td>
 				<td class="metric">scylla_per_partition_rate_limiter_allocations</td>
 				<td>counter</td>
 				<td>Number of times a entry was allocated over an empty/expired entry.</td>
@@ -2119,7 +2455,7 @@
 			
 
 				<tr>
-				<td>257</td>
+				<td>299</td>
 				<td class="metric">scylla_per_partition_rate_limiter_failed_allocations</td>
 				<td>counter</td>
 				<td>Number of times the rate limiter gave up trying to allocate.</td>
@@ -2127,7 +2463,7 @@
 			
 
 				<tr>
-				<td>258</td>
+				<td>300</td>
 				<td class="metric">scylla_per_partition_rate_limiter_load_factor</td>
 				<td>gauge</td>
 				<td>Current load factor of the hash table (upper bound, may be overestimated).</td>
@@ -2135,7 +2471,7 @@
 			
 
 				<tr>
-				<td>259</td>
+				<td>301</td>
 				<td class="metric">scylla_per_partition_rate_limiter_probe_count</td>
 				<td>counter</td>
 				<td>Number of probes made during lookups.</td>
@@ -2143,7 +2479,7 @@
 			
 
 				<tr>
-				<td>260</td>
+				<td>302</td>
 				<td class="metric">scylla_per_partition_rate_limiter_successful_lookups</td>
 				<td>counter</td>
 				<td>Number of times a lookup returned an already allocated entry.</td>
@@ -2151,7 +2487,7 @@
 			
 
 				<tr>
-				<td>261</td>
+				<td>303</td>
 				<td class="metric">scylla_query_processor_queries</td>
 				<td>counter</td>
 				<td>Counts queries by consistency level.</td>
@@ -2159,7 +2495,7 @@
 			
 
 				<tr>
-				<td>262</td>
+				<td>304</td>
 				<td class="metric">scylla_query_processor_statements_prepared</td>
 				<td>counter</td>
 				<td>Counts the total number of parsed CQL requests.</td>
@@ -2167,7 +2503,15 @@
 			
 
 				<tr>
-				<td>263</td>
+				<td>305</td>
+				<td class="metric">scylla_raft_group0_status</td>
+				<td>gauge</td>
+				<td>status of the raft group, 0 - disabled, 1 - normal, 2 - aborted</td>
+				</tr>
+			
+
+				<tr>
+				<td>306</td>
 				<td class="metric">scylla_reactor_abandoned_failed_futures</td>
 				<td>counter</td>
 				<td>Total number of abandoned failed futures, futures destroyed while still containing an exception</td>
@@ -2175,7 +2519,7 @@
 			
 
 				<tr>
-				<td>264</td>
+				<td>307</td>
 				<td class="metric">scylla_reactor_aio_bytes_read</td>
 				<td>counter</td>
 				<td>Total aio-reads bytes</td>
@@ -2183,7 +2527,7 @@
 			
 
 				<tr>
-				<td>265</td>
+				<td>308</td>
 				<td class="metric">scylla_reactor_aio_bytes_write</td>
 				<td>counter</td>
 				<td>Total aio-writes bytes</td>
@@ -2191,7 +2535,7 @@
 			
 
 				<tr>
-				<td>266</td>
+				<td>309</td>
 				<td class="metric">scylla_reactor_aio_errors</td>
 				<td>counter</td>
 				<td>Total aio errors</td>
@@ -2199,7 +2543,7 @@
 			
 
 				<tr>
-				<td>267</td>
+				<td>310</td>
 				<td class="metric">scylla_reactor_aio_outsizes</td>
 				<td>counter</td>
 				<td>Total number of aio operations that exceed IO limit</td>
@@ -2207,7 +2551,7 @@
 			
 
 				<tr>
-				<td>268</td>
+				<td>311</td>
 				<td class="metric">scylla_reactor_aio_reads</td>
 				<td>counter</td>
 				<td>Total aio-reads operations</td>
@@ -2215,7 +2559,7 @@
 			
 
 				<tr>
-				<td>269</td>
+				<td>312</td>
 				<td class="metric">scylla_reactor_aio_writes</td>
 				<td>counter</td>
 				<td>Total aio-writes operations</td>
@@ -2223,7 +2567,7 @@
 			
 
 				<tr>
-				<td>270</td>
+				<td>313</td>
 				<td class="metric">scylla_reactor_cpp_exceptions</td>
 				<td>counter</td>
 				<td>Total number of C++ exceptions</td>
@@ -2231,7 +2575,7 @@
 			
 
 				<tr>
-				<td>271</td>
+				<td>314</td>
 				<td class="metric">scylla_reactor_cpu_busy_ms</td>
 				<td>counter</td>
 				<td>Total cpu busy time in milliseconds</td>
@@ -2239,7 +2583,7 @@
 			
 
 				<tr>
-				<td>272</td>
+				<td>315</td>
 				<td class="metric">scylla_reactor_cpu_steal_time_ms</td>
 				<td>counter</td>
 				<td>Total steal time, the time in which some other process was running while Seastar was not trying to run (not sleeping).Because this is in userspace, some time that could be legitimally thought as steal time is not accounted as such. For example, if we are sleeping and can wake up but the kernel hasn't woken us up yet.</td>
@@ -2247,7 +2591,7 @@
 			
 
 				<tr>
-				<td>273</td>
+				<td>316</td>
 				<td class="metric">scylla_reactor_fstream_read_bytes</td>
 				<td>counter</td>
 				<td>Counts bytes read from disk file streams.  A high rate indicates high disk activity. Divide by fstream_reads to determine average read size.</td>
@@ -2255,7 +2599,7 @@
 			
 
 				<tr>
-				<td>274</td>
+				<td>317</td>
 				<td class="metric">scylla_reactor_fstream_read_bytes_blocked</td>
 				<td>counter</td>
 				<td>Counts the number of bytes read from disk that could not be satisfied from read-ahead buffers, and had to block. Indicates short streams, or incorrect read ahead configuration.</td>
@@ -2263,7 +2607,7 @@
 			
 
 				<tr>
-				<td>275</td>
+				<td>318</td>
 				<td class="metric">scylla_reactor_fstream_reads</td>
 				<td>counter</td>
 				<td>Counts reads from disk file streams.  A high rate indicates high disk activity. Contrast with other fstream_read* counters to locate bottlenecks.</td>
@@ -2271,7 +2615,7 @@
 			
 
 				<tr>
-				<td>276</td>
+				<td>319</td>
 				<td class="metric">scylla_reactor_fstream_reads_ahead_bytes_discarded</td>
 				<td>counter</td>
 				<td>Counts the number of buffered bytes that were read ahead of time and were discarded because they were not needed, wasting disk bandwidth. Indicates over-eager read ahead configuration.</td>
@@ -2279,7 +2623,7 @@
 			
 
 				<tr>
-				<td>277</td>
+				<td>320</td>
 				<td class="metric">scylla_reactor_fstream_reads_aheads_discarded</td>
 				<td>counter</td>
 				<td>Counts the number of times a buffer that was read ahead of time and was discarded because it was not needed, wasting disk bandwidth. Indicates over-eager read ahead configuration.</td>
@@ -2287,7 +2631,7 @@
 			
 
 				<tr>
-				<td>278</td>
+				<td>321</td>
 				<td class="metric">scylla_reactor_fstream_reads_blocked</td>
 				<td>counter</td>
 				<td>Counts the number of times a disk read could not be satisfied from read-ahead buffers, and had to block. Indicates short streams, or incorrect read ahead configuration.</td>
@@ -2295,7 +2639,7 @@
 			
 
 				<tr>
-				<td>279</td>
+				<td>322</td>
 				<td class="metric">scylla_reactor_fsyncs</td>
 				<td>counter</td>
 				<td>Total number of fsync operations</td>
@@ -2303,7 +2647,7 @@
 			
 
 				<tr>
-				<td>280</td>
+				<td>323</td>
 				<td class="metric">scylla_reactor_io_threaded_fallbacks</td>
 				<td>counter</td>
 				<td>Total number of io-threaded-fallbacks operations</td>
@@ -2311,7 +2655,7 @@
 			
 
 				<tr>
-				<td>281</td>
+				<td>324</td>
 				<td class="metric">scylla_reactor_logging_failures</td>
 				<td>counter</td>
 				<td>Total number of logging failures</td>
@@ -2319,7 +2663,7 @@
 			
 
 				<tr>
-				<td>282</td>
+				<td>325</td>
 				<td class="metric">scylla_reactor_polls</td>
 				<td>counter</td>
 				<td>Number of times pollers were executed</td>
@@ -2327,7 +2671,7 @@
 			
 
 				<tr>
-				<td>283</td>
+				<td>326</td>
 				<td class="metric">scylla_reactor_tasks_pending</td>
 				<td>gauge</td>
 				<td>Number of pending tasks in the queue</td>
@@ -2335,7 +2679,7 @@
 			
 
 				<tr>
-				<td>284</td>
+				<td>327</td>
 				<td class="metric">scylla_reactor_tasks_processed</td>
 				<td>counter</td>
 				<td>Total tasks processed</td>
@@ -2343,7 +2687,7 @@
 			
 
 				<tr>
-				<td>285</td>
+				<td>328</td>
 				<td class="metric">scylla_reactor_timers_pending</td>
 				<td>gauge</td>
 				<td>Number of tasks in the timer-pending queue</td>
@@ -2351,7 +2695,7 @@
 			
 
 				<tr>
-				<td>286</td>
+				<td>329</td>
 				<td class="metric">scylla_reactor_utilization</td>
 				<td>gauge</td>
 				<td>CPU utilization</td>
@@ -2359,7 +2703,71 @@
 			
 
 				<tr>
-				<td>287</td>
+				<td>330</td>
+				<td class="metric">scylla_repair_row_from_disk_bytes</td>
+				<td>counter</td>
+				<td>Total bytes of rows read from disk on this shard.</td>
+				</tr>
+			
+
+				<tr>
+				<td>331</td>
+				<td class="metric">scylla_repair_row_from_disk_nr</td>
+				<td>counter</td>
+				<td>Total number of rows read from disk on this shard.</td>
+				</tr>
+			
+
+				<tr>
+				<td>332</td>
+				<td class="metric">scylla_repair_rx_hashes_nr</td>
+				<td>counter</td>
+				<td>Total number of row hashes received on this shard.</td>
+				</tr>
+			
+
+				<tr>
+				<td>333</td>
+				<td class="metric">scylla_repair_rx_row_bytes</td>
+				<td>counter</td>
+				<td>Total bytes of rows received on this shard.</td>
+				</tr>
+			
+
+				<tr>
+				<td>334</td>
+				<td class="metric">scylla_repair_rx_row_nr</td>
+				<td>counter</td>
+				<td>Total number of rows received on this shard.</td>
+				</tr>
+			
+
+				<tr>
+				<td>335</td>
+				<td class="metric">scylla_repair_tx_hashes_nr</td>
+				<td>counter</td>
+				<td>Total number of row hashes sent on this shard.</td>
+				</tr>
+			
+
+				<tr>
+				<td>336</td>
+				<td class="metric">scylla_repair_tx_row_bytes</td>
+				<td>counter</td>
+				<td>Total bytes of rows sent on this shard.</td>
+				</tr>
+			
+
+				<tr>
+				<td>337</td>
+				<td class="metric">scylla_repair_tx_row_nr</td>
+				<td>counter</td>
+				<td>Total number of rows sent on this shard.</td>
+				</tr>
+			
+
+				<tr>
+				<td>338</td>
 				<td class="metric">scylla_scheduler_queue_length</td>
 				<td>gauge</td>
 				<td>Size of backlog on this queue, in tasks; indicates whether the queue is busy and/or contended</td>
@@ -2367,7 +2775,7 @@
 			
 
 				<tr>
-				<td>288</td>
+				<td>339</td>
 				<td class="metric">scylla_scheduler_runtime_ms</td>
 				<td>counter</td>
 				<td>Accumulated runtime of this task queue; an increment rate of 1000ms per second indicates full utilization</td>
@@ -2375,7 +2783,7 @@
 			
 
 				<tr>
-				<td>289</td>
+				<td>340</td>
 				<td class="metric">scylla_scheduler_shares</td>
 				<td>gauge</td>
 				<td>Shares allocated to this queue</td>
@@ -2383,7 +2791,7 @@
 			
 
 				<tr>
-				<td>290</td>
+				<td>341</td>
 				<td class="metric">scylla_scheduler_starvetime_ms</td>
 				<td>counter</td>
 				<td>Accumulated starvation time of this task queue; an increment rate of 1000ms per second indicates the scheduler feels really bad</td>
@@ -2391,7 +2799,7 @@
 			
 
 				<tr>
-				<td>291</td>
+				<td>342</td>
 				<td class="metric">scylla_scheduler_tasks_processed</td>
 				<td>counter</td>
 				<td>Count of tasks executing on this queue; indicates together with runtime_ms indicates length of tasks</td>
@@ -2399,7 +2807,7 @@
 			
 
 				<tr>
-				<td>292</td>
+				<td>343</td>
 				<td class="metric">scylla_scheduler_time_spent_on_task_quota_violations_ms</td>
 				<td>counter</td>
 				<td>Total amount in milliseconds we were in violation of the task quota</td>
@@ -2407,7 +2815,7 @@
 			
 
 				<tr>
-				<td>293</td>
+				<td>344</td>
 				<td class="metric">scylla_scheduler_waittime_ms</td>
 				<td>counter</td>
 				<td>Accumulated waittime of this task queue; an increment rate of 1000ms per second indicates queue is waiting for something (e.g. IO)</td>
@@ -2415,7 +2823,7 @@
 			
 
 				<tr>
-				<td>294</td>
+				<td>345</td>
 				<td class="metric">scylla_schema_commitlog_active_allocations</td>
 				<td>gauge</td>
 				<td>Current number of active allocations.</td>
@@ -2423,7 +2831,7 @@
 			
 
 				<tr>
-				<td>295</td>
+				<td>346</td>
 				<td class="metric">scylla_schema_commitlog_alloc</td>
 				<td>counter</td>
 				<td>Counts number of times a new mutation has been added to a segment. Divide bytes_written by this value to get the average number of bytes per mutation written to the disk.</td>
@@ -2431,7 +2839,7 @@
 			
 
 				<tr>
-				<td>296</td>
+				<td>347</td>
 				<td class="metric">scylla_schema_commitlog_allocating_segments</td>
 				<td>gauge</td>
 				<td>Holds the number of not closed segments that still have some free space. This value should not get too high.</td>
@@ -2439,7 +2847,7 @@
 			
 
 				<tr>
-				<td>297</td>
+				<td>348</td>
 				<td class="metric">scylla_schema_commitlog_blocked_on_new_segment</td>
 				<td>gauge</td>
 				<td>Number of allocations blocked on acquiring new segment.</td>
@@ -2447,7 +2855,7 @@
 			
 
 				<tr>
-				<td>298</td>
+				<td>349</td>
 				<td class="metric">scylla_schema_commitlog_bytes_flush_requested</td>
 				<td>counter</td>
 				<td>Counts number of bytes requested to be flushed (persisted).</td>
@@ -2455,7 +2863,7 @@
 			
 
 				<tr>
-				<td>299</td>
+				<td>350</td>
 				<td class="metric">scylla_schema_commitlog_bytes_released</td>
 				<td>counter</td>
 				<td>Counts number of bytes released from disk. (Deleted/recycled)</td>
@@ -2463,7 +2871,7 @@
 			
 
 				<tr>
-				<td>300</td>
+				<td>351</td>
 				<td class="metric">scylla_schema_commitlog_bytes_written</td>
 				<td>counter</td>
 				<td>Counts number of bytes written to the disk. Divide this value by "alloc" to get the average number of bytes per mutation written to the disk.</td>
@@ -2471,7 +2879,7 @@
 			
 
 				<tr>
-				<td>301</td>
+				<td>352</td>
 				<td class="metric">scylla_schema_commitlog_cycle</td>
 				<td>counter</td>
 				<td>Counts number of commitlog write cycles - when the data is written from the internal memory buffer to the disk.</td>
@@ -2479,7 +2887,7 @@
 			
 
 				<tr>
-				<td>302</td>
+				<td>353</td>
 				<td class="metric">scylla_schema_commitlog_disk_active_bytes</td>
 				<td>gauge</td>
 				<td>Holds size of disk space in bytes used for data so far. A too high value indicates that we have some bottleneck in the writing to sstables path.</td>
@@ -2487,7 +2895,7 @@
 			
 
 				<tr>
-				<td>303</td>
+				<td>354</td>
 				<td class="metric">scylla_schema_commitlog_disk_slack_end_bytes</td>
 				<td>gauge</td>
 				<td>Holds size of disk space in bytes unused because of segment switching (end slack). A too high value indicates that we do not write enough data to each segment.</td>
@@ -2495,7 +2903,7 @@
 			
 
 				<tr>
-				<td>304</td>
+				<td>355</td>
 				<td class="metric">scylla_schema_commitlog_disk_total_bytes</td>
 				<td>gauge</td>
 				<td>Holds size of disk space in bytes reserved for data so far. A too high value indicates that we have some bottleneck in the writing to sstables path.</td>
@@ -2503,7 +2911,7 @@
 			
 
 				<tr>
-				<td>305</td>
+				<td>356</td>
 				<td class="metric">scylla_schema_commitlog_flush</td>
 				<td>counter</td>
 				<td>Counts number of times the flush() method was called for a file.</td>
@@ -2511,7 +2919,7 @@
 			
 
 				<tr>
-				<td>306</td>
+				<td>357</td>
 				<td class="metric">scylla_schema_commitlog_flush_limit_exceeded</td>
 				<td>counter</td>
 				<td>Counts number of times a flush limit was exceeded. A non-zero value indicates that there are too many pending flush operations (see pending_flushes) and some of them will be blocked till the total amount of pending flush operations drops below 5.</td>
@@ -2519,7 +2927,7 @@
 			
 
 				<tr>
-				<td>307</td>
+				<td>358</td>
 				<td class="metric">scylla_schema_commitlog_memory_buffer_bytes</td>
 				<td>gauge</td>
 				<td>Holds the total number of bytes in internal memory buffers.</td>
@@ -2527,7 +2935,7 @@
 			
 
 				<tr>
-				<td>308</td>
+				<td>359</td>
 				<td class="metric">scylla_schema_commitlog_pending_allocations</td>
 				<td>gauge</td>
 				<td>Holds number of currently pending allocations. A non-zero value indicates that we have a bottleneck in the disk write flow.</td>
@@ -2535,7 +2943,7 @@
 			
 
 				<tr>
-				<td>309</td>
+				<td>360</td>
 				<td class="metric">scylla_schema_commitlog_pending_flushes</td>
 				<td>gauge</td>
 				<td>Holds number of currently pending flushes. See the related flush_limit_exceeded metric.</td>
@@ -2543,7 +2951,7 @@
 			
 
 				<tr>
-				<td>310</td>
+				<td>361</td>
 				<td class="metric">scylla_schema_commitlog_requests_blocked_memory</td>
 				<td>counter</td>
 				<td>Counts number of requests blocked due to memory pressure. A non-zero value indicates that the commitlog memory quota is not enough to serve the required amount of requests.</td>
@@ -2551,7 +2959,7 @@
 			
 
 				<tr>
-				<td>311</td>
+				<td>362</td>
 				<td class="metric">scylla_schema_commitlog_segments</td>
 				<td>gauge</td>
 				<td>Holds the current number of segments.</td>
@@ -2559,7 +2967,7 @@
 			
 
 				<tr>
-				<td>312</td>
+				<td>363</td>
 				<td class="metric">scylla_schema_commitlog_slack</td>
 				<td>counter</td>
 				<td>Counts number of unused bytes written to the disk due to disk segment alignment.</td>
@@ -2567,7 +2975,7 @@
 			
 
 				<tr>
-				<td>313</td>
+				<td>364</td>
 				<td class="metric">scylla_schema_commitlog_unused_segments</td>
 				<td>gauge</td>
 				<td>Holds the current number of unused segments. A non-zero value indicates that the disk write path became temporary slow.</td>
@@ -2575,7 +2983,7 @@
 			
 
 				<tr>
-				<td>314</td>
+				<td>365</td>
 				<td class="metric">scylla_scylladb_current_version</td>
 				<td>gauge</td>
 				<td>Current ScyllaDB version.</td>
@@ -2583,7 +2991,7 @@
 			
 
 				<tr>
-				<td>315</td>
+				<td>366</td>
 				<td class="metric">scylla_sstables_bloom_filter_memory_size</td>
 				<td>gauge</td>
 				<td>Bloom filter memory usage in bytes.</td>
@@ -2591,7 +2999,7 @@
 			
 
 				<tr>
-				<td>316</td>
+				<td>367</td>
 				<td class="metric">scylla_sstables_capped_local_deletion_time</td>
 				<td>counter</td>
 				<td>Was local deletion time capped at maximum allowed value in Statistics</td>
@@ -2599,7 +3007,7 @@
 			
 
 				<tr>
-				<td>317</td>
+				<td>368</td>
 				<td class="metric">scylla_sstables_capped_tombstone_deletion_time</td>
 				<td>counter</td>
 				<td>Was partition tombstone deletion time capped at maximum allowed value</td>
@@ -2607,7 +3015,7 @@
 			
 
 				<tr>
-				<td>318</td>
+				<td>369</td>
 				<td class="metric">scylla_sstables_cell_tombstone_writes</td>
 				<td>counter</td>
 				<td>Number of cell tombstones written</td>
@@ -2615,7 +3023,7 @@
 			
 
 				<tr>
-				<td>319</td>
+				<td>370</td>
 				<td class="metric">scylla_sstables_cell_writes</td>
 				<td>counter</td>
 				<td>Number of cells written</td>
@@ -2623,7 +3031,7 @@
 			
 
 				<tr>
-				<td>320</td>
+				<td>371</td>
 				<td class="metric">scylla_sstables_currently_open_for_reading</td>
 				<td>gauge</td>
 				<td>Number of sstables currently open for reading</td>
@@ -2631,7 +3039,7 @@
 			
 
 				<tr>
-				<td>321</td>
+				<td>372</td>
 				<td class="metric">scylla_sstables_currently_open_for_writing</td>
 				<td>gauge</td>
 				<td>Number of sstables currently open for writing</td>
@@ -2639,7 +3047,7 @@
 			
 
 				<tr>
-				<td>322</td>
+				<td>373</td>
 				<td class="metric">scylla_sstables_index_page_blocks</td>
 				<td>counter</td>
 				<td>Index page requests which needed to wait due to page not being loaded yet</td>
@@ -2647,7 +3055,7 @@
 			
 
 				<tr>
-				<td>323</td>
+				<td>374</td>
 				<td class="metric">scylla_sstables_index_page_cache_bytes</td>
 				<td>gauge</td>
 				<td>Total number of bytes cached in the index page cache</td>
@@ -2655,7 +3063,7 @@
 			
 
 				<tr>
-				<td>324</td>
+				<td>375</td>
 				<td class="metric">scylla_sstables_index_page_cache_bytes_in_std</td>
 				<td>gauge</td>
 				<td>Total number of bytes in temporary buffers which live in the std allocator</td>
@@ -2663,7 +3071,7 @@
 			
 
 				<tr>
-				<td>325</td>
+				<td>376</td>
 				<td class="metric">scylla_sstables_index_page_cache_evictions</td>
 				<td>counter</td>
 				<td>Total number of index page cache pages which have been evicted</td>
@@ -2671,7 +3079,7 @@
 			
 
 				<tr>
-				<td>326</td>
+				<td>377</td>
 				<td class="metric">scylla_sstables_index_page_cache_hits</td>
 				<td>counter</td>
 				<td>Index page cache requests which were served from cache</td>
@@ -2679,7 +3087,7 @@
 			
 
 				<tr>
-				<td>327</td>
+				<td>378</td>
 				<td class="metric">scylla_sstables_index_page_cache_misses</td>
 				<td>counter</td>
 				<td>Index page cache requests which had to perform I/O</td>
@@ -2687,7 +3095,7 @@
 			
 
 				<tr>
-				<td>328</td>
+				<td>379</td>
 				<td class="metric">scylla_sstables_index_page_cache_populations</td>
 				<td>counter</td>
 				<td>Total number of index page cache pages which were inserted into the cache</td>
@@ -2695,7 +3103,7 @@
 			
 
 				<tr>
-				<td>329</td>
+				<td>380</td>
 				<td class="metric">scylla_sstables_index_page_evictions</td>
 				<td>counter</td>
 				<td>Index pages which got evicted from memory</td>
@@ -2703,7 +3111,7 @@
 			
 
 				<tr>
-				<td>330</td>
+				<td>381</td>
 				<td class="metric">scylla_sstables_index_page_hits</td>
 				<td>counter</td>
 				<td>Index page requests which could be satisfied without waiting</td>
@@ -2711,7 +3119,7 @@
 			
 
 				<tr>
-				<td>331</td>
+				<td>382</td>
 				<td class="metric">scylla_sstables_index_page_misses</td>
 				<td>counter</td>
 				<td>Index page requests which initiated a read from disk</td>
@@ -2719,7 +3127,7 @@
 			
 
 				<tr>
-				<td>332</td>
+				<td>383</td>
 				<td class="metric">scylla_sstables_index_page_populations</td>
 				<td>counter</td>
 				<td>Index pages which got populated into memory</td>
@@ -2727,7 +3135,7 @@
 			
 
 				<tr>
-				<td>333</td>
+				<td>384</td>
 				<td class="metric">scylla_sstables_index_page_used_bytes</td>
 				<td>gauge</td>
 				<td>Amount of bytes used by index pages in memory</td>
@@ -2735,7 +3143,7 @@
 			
 
 				<tr>
-				<td>334</td>
+				<td>385</td>
 				<td class="metric">scylla_sstables_partition_reads</td>
 				<td>counter</td>
 				<td>Number of partitions read</td>
@@ -2743,7 +3151,7 @@
 			
 
 				<tr>
-				<td>335</td>
+				<td>386</td>
 				<td class="metric">scylla_sstables_partition_seeks</td>
 				<td>counter</td>
 				<td>Number of partitions seeked</td>
@@ -2751,7 +3159,7 @@
 			
 
 				<tr>
-				<td>336</td>
+				<td>387</td>
 				<td class="metric">scylla_sstables_partition_writes</td>
 				<td>counter</td>
 				<td>Number of partitions written</td>
@@ -2759,7 +3167,7 @@
 			
 
 				<tr>
-				<td>337</td>
+				<td>388</td>
 				<td class="metric">scylla_sstables_pi_auto_scale_events</td>
 				<td>counter</td>
 				<td>Number of promoted index auto-scaling events</td>
@@ -2767,7 +3175,7 @@
 			
 
 				<tr>
-				<td>338</td>
+				<td>389</td>
 				<td class="metric">scylla_sstables_pi_cache_block_count</td>
 				<td>gauge</td>
 				<td>Number of promoted index blocks currently cached</td>
@@ -2775,7 +3183,7 @@
 			
 
 				<tr>
-				<td>339</td>
+				<td>390</td>
 				<td class="metric">scylla_sstables_pi_cache_bytes</td>
 				<td>gauge</td>
 				<td>Number of bytes currently used by cached promoted index blocks</td>
@@ -2783,7 +3191,7 @@
 			
 
 				<tr>
-				<td>340</td>
+				<td>391</td>
 				<td class="metric">scylla_sstables_pi_cache_evictions</td>
 				<td>counter</td>
 				<td>Number of promoted index blocks which got evicted</td>
@@ -2791,7 +3199,7 @@
 			
 
 				<tr>
-				<td>341</td>
+				<td>392</td>
 				<td class="metric">scylla_sstables_pi_cache_hits_l0</td>
 				<td>counter</td>
 				<td>Number of requests for promoted index block in state l0 which didn't have to go to the page cache</td>
@@ -2799,7 +3207,7 @@
 			
 
 				<tr>
-				<td>342</td>
+				<td>393</td>
 				<td class="metric">scylla_sstables_pi_cache_hits_l1</td>
 				<td>counter</td>
 				<td>Number of requests for promoted index block in state l1 which didn't have to go to the page cache</td>
@@ -2807,7 +3215,7 @@
 			
 
 				<tr>
-				<td>343</td>
+				<td>394</td>
 				<td class="metric">scylla_sstables_pi_cache_hits_l2</td>
 				<td>counter</td>
 				<td>Number of requests for promoted index block in state l2 which didn't have to go to the page cache</td>
@@ -2815,7 +3223,7 @@
 			
 
 				<tr>
-				<td>344</td>
+				<td>395</td>
 				<td class="metric">scylla_sstables_pi_cache_misses_l0</td>
 				<td>counter</td>
 				<td>Number of requests for promoted index block in state l0 which had to go to the page cache</td>
@@ -2823,7 +3231,7 @@
 			
 
 				<tr>
-				<td>345</td>
+				<td>396</td>
 				<td class="metric">scylla_sstables_pi_cache_misses_l1</td>
 				<td>counter</td>
 				<td>Number of requests for promoted index block in state l1 which had to go to the page cache</td>
@@ -2831,7 +3239,7 @@
 			
 
 				<tr>
-				<td>346</td>
+				<td>397</td>
 				<td class="metric">scylla_sstables_pi_cache_misses_l2</td>
 				<td>counter</td>
 				<td>Number of requests for promoted index block in state l2 which had to go to the page cache</td>
@@ -2839,7 +3247,7 @@
 			
 
 				<tr>
-				<td>347</td>
+				<td>398</td>
 				<td class="metric">scylla_sstables_pi_cache_populations</td>
 				<td>counter</td>
 				<td>Number of promoted index blocks which got inserted</td>
@@ -2847,7 +3255,7 @@
 			
 
 				<tr>
-				<td>348</td>
+				<td>399</td>
 				<td class="metric">scylla_sstables_range_partition_reads</td>
 				<td>counter</td>
 				<td>Number of partition range flat mutation reads</td>
@@ -2855,7 +3263,7 @@
 			
 
 				<tr>
-				<td>349</td>
+				<td>400</td>
 				<td class="metric">scylla_sstables_range_tombstone_reads</td>
 				<td>counter</td>
 				<td>Number of range tombstones read</td>
@@ -2863,7 +3271,7 @@
 			
 
 				<tr>
-				<td>350</td>
+				<td>401</td>
 				<td class="metric">scylla_sstables_range_tombstone_writes</td>
 				<td>counter</td>
 				<td>Number of range tombstones written</td>
@@ -2871,7 +3279,7 @@
 			
 
 				<tr>
-				<td>351</td>
+				<td>402</td>
 				<td class="metric">scylla_sstables_row_reads</td>
 				<td>counter</td>
 				<td>Number of rows read</td>
@@ -2879,7 +3287,7 @@
 			
 
 				<tr>
-				<td>352</td>
+				<td>403</td>
 				<td class="metric">scylla_sstables_row_tombstone_reads</td>
 				<td>counter</td>
 				<td>Number of row tombstones read</td>
@@ -2887,7 +3295,7 @@
 			
 
 				<tr>
-				<td>353</td>
+				<td>404</td>
 				<td class="metric">scylla_sstables_row_writes</td>
 				<td>counter</td>
 				<td>Number of clustering rows written</td>
@@ -2895,7 +3303,7 @@
 			
 
 				<tr>
-				<td>354</td>
+				<td>405</td>
 				<td class="metric">scylla_sstables_single_partition_reads</td>
 				<td>counter</td>
 				<td>Number of single partition flat mutation reads</td>
@@ -2903,7 +3311,7 @@
 			
 
 				<tr>
-				<td>355</td>
+				<td>406</td>
 				<td class="metric">scylla_sstables_static_row_writes</td>
 				<td>counter</td>
 				<td>Number of static rows written</td>
@@ -2911,7 +3319,7 @@
 			
 
 				<tr>
-				<td>356</td>
+				<td>407</td>
 				<td class="metric">scylla_sstables_tombstone_writes</td>
 				<td>counter</td>
 				<td>Number of tombstones written</td>
@@ -2919,7 +3327,7 @@
 			
 
 				<tr>
-				<td>357</td>
+				<td>408</td>
 				<td class="metric">scylla_sstables_total_deleted</td>
 				<td>counter</td>
 				<td>Counter of deleted sstables</td>
@@ -2927,7 +3335,7 @@
 			
 
 				<tr>
-				<td>358</td>
+				<td>409</td>
 				<td class="metric">scylla_sstables_total_open_for_reading</td>
 				<td>counter</td>
 				<td>Counter of sstables open for reading</td>
@@ -2935,7 +3343,7 @@
 			
 
 				<tr>
-				<td>359</td>
+				<td>410</td>
 				<td class="metric">scylla_sstables_total_open_for_writing</td>
 				<td>counter</td>
 				<td>Counter of sstables open for writing</td>
@@ -2943,7 +3351,7 @@
 			
 
 				<tr>
-				<td>360</td>
+				<td>411</td>
 				<td class="metric">scylla_stall_detector_reported</td>
 				<td>counter</td>
 				<td>Total number of reported stalls, look in the traces for the exact reason</td>
@@ -2951,7 +3359,7 @@
 			
 
 				<tr>
-				<td>361</td>
+				<td>412</td>
 				<td class="metric">scylla_storage_proxy_coordinator_background_read_repairs</td>
 				<td>counter</td>
 				<td>number of background read repairs</td>
@@ -2959,7 +3367,7 @@
 			
 
 				<tr>
-				<td>362</td>
+				<td>413</td>
 				<td class="metric">scylla_storage_proxy_coordinator_background_reads</td>
 				<td>gauge</td>
 				<td>number of currently pending background read requests</td>
@@ -2967,7 +3375,7 @@
 			
 
 				<tr>
-				<td>363</td>
+				<td>414</td>
 				<td class="metric">scylla_storage_proxy_coordinator_background_replica_writes_failed_local_node</td>
 				<td>counter</td>
 				<td>number of replica writes that timed out or failed after CL was reachedon a local Node</td>
@@ -2975,7 +3383,15 @@
 			
 
 				<tr>
-				<td>364</td>
+				<td>415</td>
+				<td class="metric">scylla_storage_proxy_coordinator_background_replica_writes_failed_remote_node</td>
+				<td>counter</td>
+				<td>number of replica writes that timed out or failed after CL was reached when communicating with external Nodes in another DC</td>
+				</tr>
+			
+
+				<tr>
+				<td>416</td>
 				<td class="metric">scylla_storage_proxy_coordinator_background_writes</td>
 				<td>gauge</td>
 				<td>number of currently pending background write requests</td>
@@ -2983,7 +3399,7 @@
 			
 
 				<tr>
-				<td>365</td>
+				<td>417</td>
 				<td class="metric">scylla_storage_proxy_coordinator_background_writes_failed</td>
 				<td>counter</td>
 				<td>number of write requests that failed after CL was reached</td>
@@ -2991,15 +3407,7 @@
 			
 
 				<tr>
-				<td>366</td>
-				<td class="metric">scylla_storage_proxy_coordinator_canceled_read_repairs</td>
-				<td>counter</td>
-				<td>number of global read repairs canceled due to a concurrent write</td>
-				</tr>
-			
-
-				<tr>
-				<td>367</td>
+				<td>418</td>
 				<td class="metric">scylla_storage_proxy_coordinator_cas_background</td>
 				<td>gauge</td>
 				<td>how many paxos operations are still running after a result was alredy returned</td>
@@ -3007,15 +3415,7 @@
 			
 
 				<tr>
-				<td>368</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_dropped_prune</td>
-				<td>counter</td>
-				<td>how many times a coordinator did not perfom prune after cas</td>
-				</tr>
-			
-
-				<tr>
-				<td>369</td>
+				<td>419</td>
 				<td class="metric">scylla_storage_proxy_coordinator_cas_failed_read_round_optimization</td>
 				<td>counter</td>
 				<td>CAS read rounds issued only if previous value is missing on some replica</td>
@@ -3023,7 +3423,7 @@
 			
 
 				<tr>
-				<td>370</td>
+				<td>420</td>
 				<td class="metric">scylla_storage_proxy_coordinator_cas_foreground</td>
 				<td>gauge</td>
 				<td>how many paxos operations that did not yet produce a result are running</td>
@@ -3031,7 +3431,7 @@
 			
 
 				<tr>
-				<td>371</td>
+				<td>421</td>
 				<td class="metric">scylla_storage_proxy_coordinator_cas_prune</td>
 				<td>counter</td>
 				<td>how many times paxos prune was done after successful cas operation</td>
@@ -3039,47 +3439,7 @@
 			
 
 				<tr>
-				<td>372</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_read_contention</td>
-				<td>histogram</td>
-				<td>how many contended reads were encountered</td>
-				</tr>
-			
-
-				<tr>
-				<td>373</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_read_latency</td>
-				<td>histogram</td>
-				<td>Transactional read latency histogram</td>
-				</tr>
-			
-
-				<tr>
-				<td>374</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_read_timeouts</td>
-				<td>counter</td>
-				<td>number of transactional read request failed due to a timeout</td>
-				</tr>
-			
-
-				<tr>
-				<td>375</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_read_unavailable</td>
-				<td>counter</td>
-				<td>number of transactional read requests failed due to an "unavailable" error</td>
-				</tr>
-			
-
-				<tr>
-				<td>376</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_read_unfinished_commit</td>
-				<td>counter</td>
-				<td>number of transaction commit attempts that occurred on read</td>
-				</tr>
-			
-
-				<tr>
-				<td>377</td>
+				<td>422</td>
 				<td class="metric">scylla_storage_proxy_coordinator_cas_total_operations</td>
 				<td>counter</td>
 				<td>number of total paxos operations executed (reads and writes)</td>
@@ -3087,15 +3447,7 @@
 			
 
 				<tr>
-				<td>378</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_write_condition_not_met</td>
-				<td>counter</td>
-				<td>number of transaction preconditions that did not match current values</td>
-				</tr>
-			
-
-				<tr>
-				<td>379</td>
+				<td>423</td>
 				<td class="metric">scylla_storage_proxy_coordinator_cas_write_contention</td>
 				<td>histogram</td>
 				<td>how many contended writes were encountered</td>
@@ -3103,7 +3455,7 @@
 			
 
 				<tr>
-				<td>380</td>
+				<td>424</td>
 				<td class="metric">scylla_storage_proxy_coordinator_cas_write_latency</td>
 				<td>histogram</td>
 				<td>Transactional write latency histogram</td>
@@ -3111,39 +3463,15 @@
 			
 
 				<tr>
-				<td>381</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_write_timeout_due_to_uncertainty</td>
-				<td>counter</td>
-				<td>how many times write timeout was reported because of uncertainty in the result</td>
+				<td>425</td>
+				<td class="metric">scylla_storage_proxy_coordinator_cas_write_latency_summary</td>
+				<td>summary</td>
+				<td>CAS write latency summary</td>
 				</tr>
 			
 
 				<tr>
-				<td>382</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_write_timeouts</td>
-				<td>counter</td>
-				<td>number of transactional write request failed due to a timeout</td>
-				</tr>
-			
-
-				<tr>
-				<td>383</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_write_unavailable</td>
-				<td>counter</td>
-				<td>number of transactional write requests failed due to an "unavailable" error</td>
-				</tr>
-			
-
-				<tr>
-				<td>384</td>
-				<td class="metric">scylla_storage_proxy_coordinator_cas_write_unfinished_commit</td>
-				<td>counter</td>
-				<td>number of transaction commit attempts that occurred on write</td>
-				</tr>
-			
-
-				<tr>
-				<td>385</td>
+				<td>426</td>
 				<td class="metric">scylla_storage_proxy_coordinator_completed_reads_local_node</td>
 				<td>counter</td>
 				<td>number of data read requests that completedon a local Node</td>
@@ -3151,15 +3479,15 @@
 			
 
 				<tr>
-				<td>386</td>
+				<td>427</td>
 				<td class="metric">scylla_storage_proxy_coordinator_completed_reads_remote_node</td>
 				<td>counter</td>
-				<td>number of data read requests that completed when communicating with external Nodes in DC datacenter1</td>
+				<td>number of data read requests that completed when communicating with external Nodes in another DC</td>
 				</tr>
 			
 
 				<tr>
-				<td>387</td>
+				<td>428</td>
 				<td class="metric">scylla_storage_proxy_coordinator_current_throttled_base_writes</td>
 				<td>gauge</td>
 				<td>number of currently throttled base replica write requests</td>
@@ -3167,7 +3495,7 @@
 			
 
 				<tr>
-				<td>388</td>
+				<td>429</td>
 				<td class="metric">scylla_storage_proxy_coordinator_current_throttled_writes</td>
 				<td>gauge</td>
 				<td>number of currently throttled write requests</td>
@@ -3175,7 +3503,7 @@
 			
 
 				<tr>
-				<td>389</td>
+				<td>430</td>
 				<td class="metric">scylla_storage_proxy_coordinator_foreground_read_repairs</td>
 				<td>counter</td>
 				<td>number of foreground read repairs</td>
@@ -3183,7 +3511,7 @@
 			
 
 				<tr>
-				<td>390</td>
+				<td>431</td>
 				<td class="metric">scylla_storage_proxy_coordinator_foreground_reads</td>
 				<td>gauge</td>
 				<td>number of currently pending foreground read requests</td>
@@ -3191,7 +3519,7 @@
 			
 
 				<tr>
-				<td>391</td>
+				<td>432</td>
 				<td class="metric">scylla_storage_proxy_coordinator_foreground_writes</td>
 				<td>gauge</td>
 				<td>number of currently pending foreground write requests</td>
@@ -3199,7 +3527,7 @@
 			
 
 				<tr>
-				<td>392</td>
+				<td>433</td>
 				<td class="metric">scylla_storage_proxy_coordinator_last_mv_flow_control_delay</td>
 				<td>gauge</td>
 				<td>delay (in seconds) added for MV flow control in the last request</td>
@@ -3207,23 +3535,7 @@
 			
 
 				<tr>
-				<td>393</td>
-				<td class="metric">scylla_storage_proxy_coordinator_range_timeouts</td>
-				<td>counter</td>
-				<td>number of range read operations failed due to a timeout</td>
-				</tr>
-			
-
-				<tr>
-				<td>394</td>
-				<td class="metric">scylla_storage_proxy_coordinator_range_unavailable</td>
-				<td>counter</td>
-				<td>number of range read operations failed due to an "unavailable" error</td>
-				</tr>
-			
-
-				<tr>
-				<td>395</td>
+				<td>434</td>
 				<td class="metric">scylla_storage_proxy_coordinator_read_errors_local_node</td>
 				<td>counter</td>
 				<td>number of data read requests that failedon a local Node</td>
@@ -3231,15 +3543,15 @@
 			
 
 				<tr>
-				<td>396</td>
+				<td>435</td>
 				<td class="metric">scylla_storage_proxy_coordinator_read_errors_remote_node</td>
 				<td>counter</td>
-				<td>number of data read requests that failed when communicating with external Nodes in DC datacenter1</td>
+				<td>number of data read requests that failed when communicating with external Nodes in another DC</td>
 				</tr>
 			
 
 				<tr>
-				<td>397</td>
+				<td>436</td>
 				<td class="metric">scylla_storage_proxy_coordinator_read_latency</td>
 				<td>histogram</td>
 				<td>The general read latency histogram</td>
@@ -3247,15 +3559,15 @@
 			
 
 				<tr>
-				<td>398</td>
-				<td class="metric">scylla_storage_proxy_coordinator_read_rate_limited</td>
-				<td>counter</td>
-				<td>number of read requests which were rejected by replicas because rate limit for the partition was reached.</td>
+				<td>437</td>
+				<td class="metric">scylla_storage_proxy_coordinator_read_latency_summary</td>
+				<td>summary</td>
+				<td>Read latency summary</td>
 				</tr>
 			
 
 				<tr>
-				<td>399</td>
+				<td>438</td>
 				<td class="metric">scylla_storage_proxy_coordinator_read_repair_write_attempts_local_node</td>
 				<td>counter</td>
 				<td>number of write operations in a read repair contexton a local Node</td>
@@ -3263,23 +3575,15 @@
 			
 
 				<tr>
-				<td>400</td>
+				<td>439</td>
 				<td class="metric">scylla_storage_proxy_coordinator_read_repair_write_attempts_remote_node</td>
 				<td>counter</td>
-				<td>number of write operations in a read repair context when communicating with external Nodes in DC datacenter1</td>
+				<td>number of write operations in a read repair context when communicating with external Nodes in another DC</td>
 				</tr>
 			
 
 				<tr>
-				<td>401</td>
-				<td class="metric">scylla_storage_proxy_coordinator_read_retries</td>
-				<td>counter</td>
-				<td>number of read retry attempts</td>
-				</tr>
-			
-
-				<tr>
-				<td>402</td>
+				<td>440</td>
 				<td class="metric">scylla_storage_proxy_coordinator_read_timeouts</td>
 				<td>counter</td>
 				<td>number of read request failed due to a timeout</td>
@@ -3287,23 +3591,7 @@
 			
 
 				<tr>
-				<td>403</td>
-				<td class="metric">scylla_storage_proxy_coordinator_read_unavailable</td>
-				<td>counter</td>
-				<td>number read requests failed due to an "unavailable" error</td>
-				</tr>
-			
-
-				<tr>
-				<td>404</td>
-				<td class="metric">scylla_storage_proxy_coordinator_reads_coordinator_outside_replica_set</td>
-				<td>counter</td>
-				<td>number of CQL read requests which arrived to a non-replica and had to be forwarded to a replica</td>
-				</tr>
-			
-
-				<tr>
-				<td>405</td>
+				<td>441</td>
 				<td class="metric">scylla_storage_proxy_coordinator_reads_local_node</td>
 				<td>counter</td>
 				<td>number of data read requestson a local Node</td>
@@ -3311,15 +3599,15 @@
 			
 
 				<tr>
-				<td>406</td>
+				<td>442</td>
 				<td class="metric">scylla_storage_proxy_coordinator_reads_remote_node</td>
 				<td>counter</td>
-				<td>number of data read requests when communicating with external Nodes in DC datacenter1</td>
+				<td>number of data read requests when communicating with external Nodes in another DC</td>
 				</tr>
 			
 
 				<tr>
-				<td>407</td>
+				<td>443</td>
 				<td class="metric">scylla_storage_proxy_coordinator_speculative_data_reads</td>
 				<td>counter</td>
 				<td>number of speculative data read requests that were sent</td>
@@ -3327,7 +3615,7 @@
 			
 
 				<tr>
-				<td>408</td>
+				<td>444</td>
 				<td class="metric">scylla_storage_proxy_coordinator_speculative_digest_reads</td>
 				<td>counter</td>
 				<td>number of speculative digest read requests that were sent</td>
@@ -3335,15 +3623,7 @@
 			
 
 				<tr>
-				<td>409</td>
-				<td class="metric">scylla_storage_proxy_coordinator_throttled_writes</td>
-				<td>counter</td>
-				<td>number of throttled write requests</td>
-				</tr>
-			
-
-				<tr>
-				<td>410</td>
+				<td>445</td>
 				<td class="metric">scylla_storage_proxy_coordinator_total_write_attempts_local_node</td>
 				<td>counter</td>
 				<td>total number of write requestson a local Node</td>
@@ -3351,15 +3631,15 @@
 			
 
 				<tr>
-				<td>411</td>
+				<td>446</td>
 				<td class="metric">scylla_storage_proxy_coordinator_total_write_attempts_remote_node</td>
 				<td>counter</td>
-				<td>total number of write requests when communicating with external Nodes in DC datacenter1</td>
+				<td>total number of write requests when communicating with external Nodes in another DC</td>
 				</tr>
 			
 
 				<tr>
-				<td>412</td>
+				<td>447</td>
 				<td class="metric">scylla_storage_proxy_coordinator_write_errors_local_node</td>
 				<td>counter</td>
 				<td>number of write requests that failedon a local Node</td>
@@ -3367,7 +3647,7 @@
 			
 
 				<tr>
-				<td>413</td>
+				<td>448</td>
 				<td class="metric">scylla_storage_proxy_coordinator_write_latency</td>
 				<td>histogram</td>
 				<td>The general write latency histogram</td>
@@ -3375,15 +3655,15 @@
 			
 
 				<tr>
-				<td>414</td>
-				<td class="metric">scylla_storage_proxy_coordinator_write_rate_limited</td>
-				<td>counter</td>
-				<td>number of write requests which were rejected by replicas because rate limit for the partition was reached.</td>
+				<td>449</td>
+				<td class="metric">scylla_storage_proxy_coordinator_write_latency_summary</td>
+				<td>summary</td>
+				<td>Write latency summary</td>
 				</tr>
 			
 
 				<tr>
-				<td>415</td>
+				<td>450</td>
 				<td class="metric">scylla_storage_proxy_coordinator_write_timeouts</td>
 				<td>counter</td>
 				<td>number of write request failed due to a timeout</td>
@@ -3391,39 +3671,7 @@
 			
 
 				<tr>
-				<td>416</td>
-				<td class="metric">scylla_storage_proxy_coordinator_write_unavailable</td>
-				<td>counter</td>
-				<td>number write requests failed due to an "unavailable" error</td>
-				</tr>
-			
-
-				<tr>
-				<td>417</td>
-				<td class="metric">scylla_storage_proxy_coordinator_writes_coordinator_outside_replica_set</td>
-				<td>counter</td>
-				<td>number of CQL write requests which arrived to a non-replica and had to be forwarded to a replica</td>
-				</tr>
-			
-
-				<tr>
-				<td>418</td>
-				<td class="metric">scylla_storage_proxy_coordinator_writes_failed_due_to_too_many_in_flight_hints</td>
-				<td>counter</td>
-				<td>number of CQL write requests which failed because the hinted handoff mechanism is overloaded and cannot store any more in-flight hints</td>
-				</tr>
-			
-
-				<tr>
-				<td>419</td>
-				<td class="metric">scylla_storage_proxy_replica_cas_dropped_prune</td>
-				<td>counter</td>
-				<td>how many times a coordinator did not perfom prune after cas</td>
-				</tr>
-			
-
-				<tr>
-				<td>420</td>
+				<td>451</td>
 				<td class="metric">scylla_storage_proxy_replica_cross_shard_ops</td>
 				<td>counter</td>
 				<td>number of operations that crossed a shard boundary</td>
@@ -3431,23 +3679,7 @@
 			
 
 				<tr>
-				<td>421</td>
-				<td class="metric">scylla_storage_proxy_replica_forwarded_mutations</td>
-				<td>counter</td>
-				<td>number of mutations forwarded to other replica Nodes</td>
-				</tr>
-			
-
-				<tr>
-				<td>422</td>
-				<td class="metric">scylla_storage_proxy_replica_forwarding_errors</td>
-				<td>counter</td>
-				<td>number of errors during forwarding mutations to other replica Nodes</td>
-				</tr>
-			
-
-				<tr>
-				<td>423</td>
+				<td>452</td>
 				<td class="metric">scylla_storage_proxy_replica_reads</td>
 				<td>counter</td>
 				<td>number of remote data read requests this Node received</td>
@@ -3455,15 +3687,7 @@
 			
 
 				<tr>
-				<td>424</td>
-				<td class="metric">scylla_storage_proxy_replica_received_counter_updates</td>
-				<td>counter</td>
-				<td>number of counter updates received by this node acting as an update leader</td>
-				</tr>
-			
-
-				<tr>
-				<td>425</td>
+				<td>453</td>
 				<td class="metric">scylla_storage_proxy_replica_received_mutations</td>
 				<td>counter</td>
 				<td>number of mutations received by a replica Node</td>
@@ -3471,7 +3695,15 @@
 			
 
 				<tr>
-				<td>426</td>
+				<td>454</td>
+				<td class="metric">scylla_streaming_finished_percentage</td>
+				<td>gauge</td>
+				<td>Finished percentage of node operation on this shard</td>
+				</tr>
+			
+
+				<tr>
+				<td>455</td>
 				<td class="metric">scylla_streaming_total_incoming_bytes</td>
 				<td>counter</td>
 				<td>Total number of bytes received on this shard.</td>
@@ -3479,7 +3711,7 @@
 			
 
 				<tr>
-				<td>427</td>
+				<td>456</td>
 				<td class="metric">scylla_streaming_total_outgoing_bytes</td>
 				<td>counter</td>
 				<td>Total number of bytes sent on this shard.</td>
@@ -3487,7 +3719,7 @@
 			
 
 				<tr>
-				<td>428</td>
+				<td>457</td>
 				<td class="metric">scylla_tracing_active_sessions</td>
 				<td>gauge</td>
 				<td>Holds a number of a currently active tracing sessions.</td>
@@ -3495,7 +3727,7 @@
 			
 
 				<tr>
-				<td>429</td>
+				<td>458</td>
 				<td class="metric">scylla_tracing_cached_records</td>
 				<td>gauge</td>
 				<td>Holds a number of tracing records cached in the tracing sessions that are not going to be written in the next write event. If sum of this metric, pending_for_write_records and flushing_records is close to 11000 we are likely to start dropping tracing records.</td>
@@ -3503,7 +3735,7 @@
 			
 
 				<tr>
-				<td>430</td>
+				<td>459</td>
 				<td class="metric">scylla_tracing_dropped_records</td>
 				<td>counter</td>
 				<td>Counts a number of dropped records due to too many pending records. High value indicates that backend is saturated with the rate with which new tracing records are created.</td>
@@ -3511,7 +3743,7 @@
 			
 
 				<tr>
-				<td>431</td>
+				<td>460</td>
 				<td class="metric">scylla_tracing_dropped_sessions</td>
 				<td>counter</td>
 				<td>Counts a number of dropped sessions due to too many pending sessions/records. High value indicates that backend is saturated with the rate with which new tracing records are created.</td>
@@ -3519,7 +3751,7 @@
 			
 
 				<tr>
-				<td>432</td>
+				<td>461</td>
 				<td class="metric">scylla_tracing_flushing_records</td>
 				<td>gauge</td>
 				<td>Holds a number of tracing records that currently being written to the I/O backend. If sum of this metric, cached_records and pending_for_write_records is close to 11000 we are likely to start dropping tracing records.</td>
@@ -3527,7 +3759,7 @@
 			
 
 				<tr>
-				<td>433</td>
+				<td>462</td>
 				<td class="metric">scylla_tracing_keyspace_helper_bad_column_family_errors</td>
 				<td>counter</td>
 				<td>Counts a number of times write failed due to one of the tables in the system_traces keyspace has an incompatible schema. One error may result one or more tracing records to be lost. Non-zero value indicates that the administrator has to take immediate steps to fix the corresponding schema. The appropriate error message will be printed in the syslog.</td>
@@ -3535,7 +3767,7 @@
 			
 
 				<tr>
-				<td>434</td>
+				<td>463</td>
 				<td class="metric">scylla_tracing_keyspace_helper_tracing_errors</td>
 				<td>counter</td>
 				<td>Counts a number of errors during writing to a system_traces keyspace. One error may cause one or more tracing records to be lost.</td>
@@ -3543,7 +3775,7 @@
 			
 
 				<tr>
-				<td>435</td>
+				<td>464</td>
 				<td class="metric">scylla_tracing_pending_for_write_records</td>
 				<td>gauge</td>
 				<td>Holds a number of tracing records that are going to be written in the next write event. If sum of this metric, cached_records and flushing_records is close to 11000 we are likely to start dropping tracing records.</td>
@@ -3551,7 +3783,7 @@
 			
 
 				<tr>
-				<td>436</td>
+				<td>465</td>
 				<td class="metric">scylla_tracing_trace_errors</td>
 				<td>counter</td>
 				<td>Counts a number of trace records dropped due to an error (e.g. OOM).</td>
@@ -3559,7 +3791,7 @@
 			
 
 				<tr>
-				<td>437</td>
+				<td>466</td>
 				<td class="metric">scylla_tracing_trace_records_count</td>
 				<td>counter</td>
 				<td>This metric is a rate of tracing records generation.</td>
@@ -3567,7 +3799,7 @@
 			
 
 				<tr>
-				<td>438</td>
+				<td>467</td>
 				<td class="metric">scylla_transport_auth_responses</td>
 				<td>counter</td>
 				<td>Counts the total number of received CQL AUTH messages.</td>
@@ -3575,7 +3807,7 @@
 			
 
 				<tr>
-				<td>439</td>
+				<td>468</td>
 				<td class="metric">scylla_transport_batch_requests</td>
 				<td>counter</td>
 				<td>Counts the total number of received CQL BATCH messages.</td>
@@ -3583,7 +3815,7 @@
 			
 
 				<tr>
-				<td>440</td>
+				<td>469</td>
 				<td class="metric">scylla_transport_cql_connections</td>
 				<td>counter</td>
 				<td>Counts a number of client connections.</td>
@@ -3591,7 +3823,7 @@
 			
 
 				<tr>
-				<td>441</td>
+				<td>470</td>
 				<td class="metric">scylla_transport_cql_errors_total</td>
 				<td>counter</td>
 				<td>Counts the total number of returned CQL errors.</td>
@@ -3599,7 +3831,7 @@
 			
 
 				<tr>
-				<td>442</td>
+				<td>471</td>
 				<td class="metric">scylla_transport_current_connections</td>
 				<td>gauge</td>
 				<td>Holds a current number of client connections.</td>
@@ -3607,7 +3839,7 @@
 			
 
 				<tr>
-				<td>443</td>
+				<td>472</td>
 				<td class="metric">scylla_transport_execute_requests</td>
 				<td>counter</td>
 				<td>Counts the total number of received CQL EXECUTE messages.</td>
@@ -3615,7 +3847,7 @@
 			
 
 				<tr>
-				<td>444</td>
+				<td>473</td>
 				<td class="metric">scylla_transport_options_requests</td>
 				<td>counter</td>
 				<td>Counts the total number of received CQL OPTIONS messages.</td>
@@ -3623,7 +3855,7 @@
 			
 
 				<tr>
-				<td>445</td>
+				<td>474</td>
 				<td class="metric">scylla_transport_prepare_requests</td>
 				<td>counter</td>
 				<td>Counts the total number of received CQL PREPARE messages.</td>
@@ -3631,7 +3863,7 @@
 			
 
 				<tr>
-				<td>446</td>
+				<td>475</td>
 				<td class="metric">scylla_transport_query_requests</td>
 				<td>counter</td>
 				<td>Counts the total number of received CQL QUERY messages.</td>
@@ -3639,7 +3871,7 @@
 			
 
 				<tr>
-				<td>447</td>
+				<td>476</td>
 				<td class="metric">scylla_transport_register_requests</td>
 				<td>counter</td>
 				<td>Counts the total number of received CQL REGISTER messages.</td>
@@ -3647,31 +3879,31 @@
 			
 
 				<tr>
-				<td>448</td>
+				<td>477</td>
 				<td class="metric">scylla_transport_requests_blocked_memory</td>
 				<td>counter</td>
-				<td>Holds an incrementing counter with the requests that ever blocked due to reaching the memory quota limit (183500800B). The first derivative of this value shows how often we block due to memory exhaustion in the "CQL transport" component.</td>
+				<td>Holds an incrementing counter with the requests that ever blocked due to reaching the memory quota limit (177838489B). The first derivative of this value shows how often we block due to memory exhaustion in the "CQL transport" component.</td>
 				</tr>
 			
 
 				<tr>
-				<td>449</td>
+				<td>478</td>
 				<td class="metric">scylla_transport_requests_blocked_memory_current</td>
 				<td>gauge</td>
-				<td>Holds the number of requests that are currently blocked due to reaching the memory quota limit (183500800B). Non-zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the "CQL transport" component.</td>
+				<td>Holds the number of requests that are currently blocked due to reaching the memory quota limit (177838489B). Non-zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the "CQL transport" component.</td>
 				</tr>
 			
 
 				<tr>
-				<td>450</td>
+				<td>479</td>
 				<td class="metric">scylla_transport_requests_memory_available</td>
 				<td>gauge</td>
-				<td>Holds the amount of available memory for admitting new requests (max is 183500800B).Zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the "CQL transport" component.</td>
+				<td>Holds the amount of available memory for admitting new requests (max is 177838489B).Zero value indicates that our bottleneck is memory and more specifically - the memory quota allocated for the "CQL transport" component.</td>
 				</tr>
 			
 
 				<tr>
-				<td>451</td>
+				<td>480</td>
 				<td class="metric">scylla_transport_requests_served</td>
 				<td>counter</td>
 				<td>Counts a number of served requests.</td>
@@ -3679,7 +3911,7 @@
 			
 
 				<tr>
-				<td>452</td>
+				<td>481</td>
 				<td class="metric">scylla_transport_requests_serving</td>
 				<td>gauge</td>
 				<td>Holds a number of requests that are being processed right now.</td>
@@ -3687,7 +3919,7 @@
 			
 
 				<tr>
-				<td>453</td>
+				<td>482</td>
 				<td class="metric">scylla_transport_requests_shed</td>
 				<td>counter</td>
 				<td>Holds an incrementing counter with the requests that were shed due to overload (threshold configured via max_concurrent_requests_per_shard). The first derivative of this value shows how often we shed requests due to overload in the "CQL transport" component.</td>
@@ -3695,7 +3927,7 @@
 			
 
 				<tr>
-				<td>454</td>
+				<td>483</td>
 				<td class="metric">scylla_transport_startups</td>
 				<td>counter</td>
 				<td>Counts the total number of received CQL STARTUP messages.</td>
@@ -3703,7 +3935,7 @@
 			
 
 				<tr>
-				<td>455</td>
+				<td>484</td>
 				<td class="metric">scylla_view_builder_builds_in_progress</td>
 				<td>gauge</td>
 				<td>Number of currently active view builds.</td>
@@ -3711,7 +3943,7 @@
 			
 
 				<tr>
-				<td>456</td>
+				<td>485</td>
 				<td class="metric">scylla_view_builder_pending_bookkeeping_ops</td>
 				<td>gauge</td>
 				<td>Number of tasks waiting to perform bookkeeping operations</td>
@@ -3719,7 +3951,7 @@
 			
 
 				<tr>
-				<td>457</td>
+				<td>486</td>
 				<td class="metric">scylla_view_builder_steps_failed</td>
 				<td>counter</td>
 				<td>Number of failed build steps.</td>
@@ -3727,7 +3959,7 @@
 			
 
 				<tr>
-				<td>458</td>
+				<td>487</td>
 				<td class="metric">scylla_view_builder_steps_performed</td>
 				<td>counter</td>
 				<td>Number of performed build steps.</td>
@@ -3735,7 +3967,7 @@
 			
 
 				<tr>
-				<td>459</td>
+				<td>488</td>
 				<td class="metric">scylla_view_update_generator_pending_registrations</td>
 				<td>gauge</td>
 				<td>Number of tasks waiting to register staging sstables</td>
@@ -3743,7 +3975,7 @@
 			
 
 				<tr>
-				<td>460</td>
+				<td>489</td>
 				<td class="metric">scylla_view_update_generator_queued_batches_count</td>
 				<td>gauge</td>
 				<td>Number of sets of sstables queued for view update generation</td>
@@ -3751,7 +3983,15 @@
 			
 
 				<tr>
-				<td>461</td>
+				<td>490</td>
+				<td class="metric">scylla_view_update_generator_sstables_pending_work</td>
+				<td>gauge</td>
+				<td>Number of bytes remaining to be processed from SSTables for view updates</td>
+				</tr>
+			
+
+				<tr>
+				<td>491</td>
 				<td class="metric">scylla_view_update_generator_sstables_to_move_count</td>
 				<td>gauge</td>
 				<td>Number of sets of sstables which are already processed and wait to be moved from their staging directory</td>
@@ -3761,7 +4001,7 @@
 	</table>
 
 	<footer>
-		Generated on 2023-02-07. Edit at <a href="https://github.com/knadh/scylladb-metrics">knadh/scylladb-metrics</a>.
+		Generated on 2024-01-08. Edit at <a href="https://github.com/knadh/scylladb-metrics">knadh/scylladb-metrics</a>.
 	</footer>
 
 	<script>


### PR DESCRIPTION
Add additional keyspace metrics exposed with `enable_keyspace_column_family_metrics: true` on a ScyllaDB host.